### PR TITLE
chore: add coding conventions to CLAUDE.md, auto-restart bot after CI…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,13 @@ jobs:
           name: Create env
           command: |
             echo "DISCORD_TOKEN=${DISCORD_TOKEN}" >> .env
+            echo "DISCORD_APP_ID=${DISCORD_APP_ID}" >> .env
             echo "NOTION_TOKEN=${NOTION_TOKEN}" >> .env
             echo "NOTION_USER_DB_ID=${NOTION_USER_DB_ID}" >> .env
             echo "NOTION_OTHERS_DB_ID=${NOTION_OTHERS_DB_ID}" >> .env
+            echo "NOTION_ORDER_DB_ID=${NOTION_ORDER_DB_ID}" >> .env
             echo "DISCORD_GUILD_LOG_CHANNEL_ID=${DISCORD_GUILD_LOG_CHANNEL_ID}" >> .env
+            echo "EXCHANGE_RATE_JPY_TWD=${EXCHANGE_RATE_JPY_TWD}" >> .env
             echo "WORKER_CORNTAB=${WORKER_CORNTAB}" >> .env
       - persist_to_workspace:
           root: ./
@@ -55,6 +58,7 @@ jobs:
           echo "ssh.xgnid.space ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINw83wSAmzc8a+6ogibQ1lExzdfFCU83tUKy7uPRzuHU" >> ~/.ssh/known_hosts
           mv /tmp/workspace/.env ./.env
           rsync -va --delete ./ $SSH_USER@$SSH_HOST:gx5
+          ssh $SSH_USER@$SSH_HOST "sudo systemctl restart discordbot"
 
 workflows:
   sample:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,20 +72,56 @@ Clean Architecture with 4 layers. Dependencies point inward only.
 main.go (wiring)
   ├── config/          ← env loading & validation
   ├── domain/          ← entities (no external deps)
-  │   └── user.go
+  │   ├── user.go
+  │   ├── order.go
+  │   └── transaction.go
   ├── port/            ← interfaces between layers
-  │   ├── repository.go  (UserRepository)
-  │   └── notifier.go    (Notifier)
+  │   ├── repository.go      (UserRepository)
+  │   ├── notifier.go        (Notifier)
+  │   ├── order_repository.go (OrderRepository)
+  │   ├── order_creator.go   (OrderCreator)
+  │   ├── transaction_repository.go (TransactionRepository)
+  │   └── buy_record.go      (BuyRecordRegisterer)
   ├── usecase/         ← business logic
-  │   └── notify_unpaid.go
+  │   ├── notify_unpaid.go
+  │   ├── create_order.go
+  │   └── register_buy_record.go
   └── gateway/         ← external service adapters
-      ├── notion/        (implements port.UserRepository)
-      │   └── user_repository.go
-      └── discord/       (implements port.Notifier)
-          └── notifier.go
+      ├── notion/        (implements port.UserRepository, OrderRepository, TransactionRepository)
+      │   ├── user_repository.go
+      │   ├── order_repository.go
+      │   └── transaction_repository.go
+      └── discord/
+          ├── notifier.go       (implements port.Notifier)
+          ├── thread_creator.go (implements port.ThreadCreator)
+          └── command/          (slash/message command handlers)
+              ├── command_handler.go
+              ├── respond.go
+              ├── new_order_handler.go
+              └── buy_command.go
 ```
 
 Dependency rule: `gateway` → `domain`, `usecase` → `port` → `domain`. No layer imports `gateway` or `usecase` except `main.go`.
+
+---
+
+## Coding Conventions
+
+### Discord Command Handlers (`gateway/discord/command/`)
+
+- **Registration pattern:** All commands must use `RegisterXxxCommand(ch *Handler, uc port.Interface)`. The function creates the command definition, registers it with the handler, and wires the interaction callback internally. Do not expose `NewXxxCommand()` + `HandleXxx()` as separate functions.
+- **Port interfaces:** Command handlers must depend on port interfaces (e.g., `port.OrderCreator`), never on concrete usecase types. Define the interface in `port/` with an `Execute` method matching the usecase signature.
+- **Response helpers:** Use `respondError(s, i, msg)` for ephemeral error messages and `respondSuccess(s, i, msg)` for visible success messages. Both are defined in `gateway/discord/command/respond.go`. Do not create per-file response helpers.
+- **User-facing text:** All Discord-visible text (command descriptions, option descriptions, modal titles/labels, error messages, success messages) must be in Chinese. Command `Name` fields and option `Name` fields must remain ASCII (Discord requirement).
+- **Named constants:** Command names, modal prefixes, and input custom IDs must be `const` at the top of the file. No magic strings in handler logic.
+
+### Business Logic
+
+- **No hardcoded business values:** Configurable values (exchange rates, thresholds, IDs) must come from environment variables loaded in `config/`. Only use constants for truly fixed values (e.g., valid tag names defined in domain).
+
+### Test Conventions (`gateway/notion/`)
+
+- **Hand-rolled mocks** for `notionapi` services (`mockDatabaseService`, `mockPageService`) live in `gateway/notion/mock_test.go`. Do not define mocks in individual test files.
 
 ---
 
@@ -104,11 +140,14 @@ Dependency rule: `gateway` → `domain`, `usecase` → `port` → `domain`. No l
 | Variable | Purpose |
 |---|---|
 | `DISCORD_TOKEN` | Discord bot token |
+| `DISCORD_APP_ID` | Discord application ID (for slash command registration) |
 | `DISCORD_GUILD` | Guild name (informational) |
 | `DISCORD_GUILD_LOG_CHANNEL_ID` | Channel ID for logging |
 | `NOTION_TOKEN` | Notion API token |
 | `NOTION_USER_DB_ID` | Notion user database ID |
 | `NOTION_OTHERS_DB_ID` | Notion shared "其他" database ID |
+| `NOTION_ORDER_DB_ID` | Notion Order List database ID (TBL-004) |
+| `EXCHANGE_RATE_JPY_TWD` | JPY to TWD exchange rate (e.g. `0.24`) |
 | `WORKER_CORNTAB` | Cron schedule (e.g. `*/1 * * * *`) |
 | `DEBUG` | Set to `1` to enable debug mode |
 
@@ -156,7 +195,5 @@ gofumpt                   # format
 ---
 
 ## Current Branch
-
-`add_debug_mode` — adds debug mode feature (prevents real DMs when `DEBUG=1`)
 
 Main branch is `main`.


### PR DESCRIPTION
… deploy

CLAUDE.md:
- Add coding conventions for command handlers, business logic, and tests
- Update architecture diagram with UC-002/UC-003 files
- Update env vars table with DISCORD_APP_ID, NOTION_ORDER_DB_ID, EXCHANGE_RATE_JPY_TWD

CircleCI:
- Auto-restart discordbot service after rsync deploy
- Add missing env vars to .env creation (DISCORD_APP_ID, NOTION_ORDER_DB_ID, EXCHANGE_RATE_JPY_TWD)