### PR TITLE
fix: resolve /neworder interaction timeout and role mention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Dependency rule: `gateway` → `domain`, `usecase` → `port` → `domain`. No l
 | `NOTION_OTHERS_DB_ID` | Notion shared "其他" database ID |
 | `WORKER_CORNTAB` | Cron schedule (e.g. `*/1 * * * *`) |
 | `DEBUG` | Set to `1` to enable debug mode |
+| `TAG_ROLE_MAP` | Comma-separated tag=roleID pairs for Discord role mentions |
 
 ---
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 type Config struct {
@@ -17,6 +18,7 @@ type Config struct {
 	ExchangeRateJPYTWD  float64
 	WorkerCrontab       string
 	Debug               bool
+	TagRoleMap          map[string]string
 }
 
 func Load() (Config, error) {
@@ -31,6 +33,7 @@ func Load() (Config, error) {
 		WorkerCrontab:       os.Getenv("WORKER_CORNTAB"),
 		Debug:               os.Getenv("DEBUG") == "1",
 	}
+	cfg.TagRoleMap = parseTagRoleMap(os.Getenv("TAG_ROLE_MAP"))
 
 	rate, err := strconv.ParseFloat(os.Getenv("EXCHANGE_RATE_JPY_TWD"), 64)
 	if err != nil || rate <= 0 {
@@ -76,4 +79,20 @@ func Load() (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func parseTagRoleMap(raw string) map[string]string {
+	m := make(map[string]string)
+	if raw == "" {
+		return m
+	}
+
+	for _, pair := range strings.Split(raw, ",") {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) == 2 {
+			m[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+
+	return m
 }

--- a/config/config.go
+++ b/config/config.go
@@ -81,15 +81,17 @@ func Load() (Config, error) {
 	return cfg, nil
 }
 
+const tagRoleMapParts = 2
+
 func parseTagRoleMap(raw string) map[string]string {
 	m := make(map[string]string)
 	if raw == "" {
 		return m
 	}
 
-	for _, pair := range strings.Split(raw, ",") {
-		parts := strings.SplitN(pair, "=", 2)
-		if len(parts) == 2 {
+	for pair := range strings.SplitSeq(raw, ",") {
+		parts := strings.SplitN(pair, "=", tagRoleMapParts)
+		if len(parts) == tagRoleMapParts {
 			m[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTagRoleMap(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want map[string]string
+	}{
+		{"empty", "", map[string]string{}},
+		{"single", "283pro=111", map[string]string{"283pro": "111"}},
+		{"multiple", "283pro=111,315pro=222", map[string]string{"283pro": "111", "315pro": "222"}},
+		{"with spaces", " 283pro = 111 , 315pro = 222 ", map[string]string{"283pro": "111", "315pro": "222"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTagRoleMap(tt.raw)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/gateway/discord/command/new_order_handler.go
+++ b/gateway/discord/command/new_order_handler.go
@@ -59,6 +59,8 @@ func RegisterNewOrderCommand(ch *Handler, uc port.OrderCreator) {
 func handleNewOrder(
 	s *discordgo.Session, i *discordgo.InteractionCreate, uc port.OrderCreator,
 ) {
+	respondDeferred(s, i)
+
 	opts := i.ApplicationCommandData().Options
 	optMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(opts))
 
@@ -87,12 +89,12 @@ func handleNewOrder(
 	err := uc.Execute(context.Background(), i.ChannelID, order)
 	if err != nil {
 		log.Printf("create order failed: %s", err)
-		respondError(s, i, "建立訂單失敗")
+		editDeferredResponse(s, i, "建立訂單失敗")
 
 		return
 	}
 
-	respondSuccess(s, i, "訂單已建立: "+order.ThreadName)
+	editDeferredResponse(s, i, "訂單已建立: "+order.ThreadName)
 }
 
 func tagChoices() []*discordgo.ApplicationCommandOptionChoice {

--- a/gateway/discord/command/respond.go
+++ b/gateway/discord/command/respond.go
@@ -30,3 +30,21 @@ func respondSuccess(s *discordgo.Session, i *discordgo.InteractionCreate, msg st
 		log.Printf("error responding to interaction: %s", err)
 	}
 }
+
+func respondDeferred(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+	})
+	if err != nil {
+		log.Printf("error deferring interaction response: %s", err)
+	}
+}
+
+func editDeferredResponse(s *discordgo.Session, i *discordgo.InteractionCreate, msg string) {
+	_, err := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: &msg,
+	})
+	if err != nil {
+		log.Printf("error editing deferred response: %s", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	orderRepo := notiongw.NewOrderRepository(notionClient.Page, cfg.NotionOrderDBID)
 	threadCreator := discordgw.NewThreadCreator(dc)
-	createOrderUC := usecase.NewCreateOrder(orderRepo, threadCreator)
+	createOrderUC := usecase.NewCreateOrder(orderRepo, threadCreator, cfg.TagRoleMap)
 
 	txRepo := notiongw.NewTransactionRepository(notionClient.Page)
 	buyUC := usecase.NewRegisterBuyRecord(repo, txRepo, cfg.ExchangeRateJPYTWD)

--- a/usecase/create_order.go
+++ b/usecase/create_order.go
@@ -12,14 +12,16 @@ import (
 type CreateOrder struct {
 	repo          port.OrderRepository
 	threadCreator port.ThreadCreator
+	tagRoleMap    map[string]string
 }
 
 func NewCreateOrder(
-	repo port.OrderRepository, threadCreator port.ThreadCreator,
+	repo port.OrderRepository, threadCreator port.ThreadCreator, tagRoleMap map[string]string,
 ) *CreateOrder {
 	return &CreateOrder{
 		repo:          repo,
 		threadCreator: threadCreator,
+		tagRoleMap:    tagRoleMap,
 	}
 }
 
@@ -30,7 +32,7 @@ func (uc *CreateOrder) Execute(
 		return fmt.Errorf("orderTitle is required")
 	}
 
-	message := buildThreadMessage(order)
+	message := buildThreadMessage(order, uc.tagRoleMap)
 
 	err := uc.threadCreator.CreateThread(ctx, channelID, order.ThreadName, message)
 	if err != nil {
@@ -45,7 +47,7 @@ func (uc *CreateOrder) Execute(
 	return nil
 }
 
-func buildThreadMessage(order domain.Order) string {
+func buildThreadMessage(order domain.Order, tagRoleMap map[string]string) string {
 	var lines []string
 
 	if order.ShopURL != "" {
@@ -53,7 +55,11 @@ func buildThreadMessage(order domain.Order) string {
 	}
 
 	if order.Tag != "" {
-		lines = append(lines, fmt.Sprintf("@%s", order.Tag))
+		if roleID, ok := tagRoleMap[string(order.Tag)]; ok {
+			lines = append(lines, fmt.Sprintf("<@&%s>", roleID))
+		} else {
+			lines = append(lines, fmt.Sprintf("@%s", order.Tag))
+		}
 	}
 
 	if order.Deadline != "" {

--- a/usecase/create_order_test.go
+++ b/usecase/create_order_test.go
@@ -17,7 +17,7 @@ func TestCreateOrder_MissingOrderTitle(t *testing.T) {
 	repo := mocks.NewOrderRepository(t)
 	tc := mocks.NewThreadCreator(t)
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", domain.Order{})
 
@@ -32,7 +32,7 @@ func TestCreateOrder_ThreadCreationError(t *testing.T) {
 	tc.On("CreateThread", mock.Anything, "ch-1", "test order", mock.Anything).
 		Return(errors.New("discord error"))
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", domain.Order{
 		ThreadName: "test order",
@@ -51,7 +51,7 @@ func TestCreateOrder_NotionError(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, domain.Order{ThreadName: "test order"}).
 		Return(errors.New("notion error"))
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", domain.Order{
 		ThreadName: "test order",
@@ -72,14 +72,15 @@ func TestCreateOrder_Success_AllFields(t *testing.T) {
 		Tag:        domain.Tag315Pro,
 	}
 
-	expectedMessage := "https://shop.example.com\n@315pro\n截止時間: 2026-04-01"
+	tagRoleMap := map[string]string{"315pro": "123456"}
+	expectedMessage := "https://shop.example.com\n<@&123456>\n截止時間: 2026-04-01"
 
 	tc.On("CreateThread", mock.Anything, "ch-1", "test order", expectedMessage).
 		Return(nil)
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, tagRoleMap)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -99,7 +100,7 @@ func TestCreateOrder_Success_OnlyTitle(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -122,7 +123,7 @@ func TestCreateOrder_Success_PartialFields(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -145,7 +146,7 @@ func TestCreateOrder_Success_ShopURLOnly(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -161,14 +162,39 @@ func TestCreateOrder_Success_TagOnly(t *testing.T) {
 		Tag:        domain.TagGakumas,
 	}
 
-	expectedMessage := "@学マス"
+	tagRoleMap := map[string]string{"学マス": "789012"}
+	expectedMessage := "<@&789012>"
 
 	tc.On("CreateThread", mock.Anything, "ch-1", "tag order", expectedMessage).
 		Return(nil)
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc)
+	uc := usecase.NewCreateOrder(repo, tc, tagRoleMap)
+
+	err := uc.Execute(context.Background(), "ch-1", order)
+
+	require.NoError(t, err)
+}
+
+func TestCreateOrder_Success_TagWithoutRoleID(t *testing.T) {
+	repo := mocks.NewOrderRepository(t)
+	tc := mocks.NewThreadCreator(t)
+
+	order := domain.Order{
+		ThreadName: "fallback order",
+		Tag:        domain.Tag283Pro,
+	}
+
+	tagRoleMap := map[string]string{}
+	expectedMessage := "@283pro"
+
+	tc.On("CreateThread", mock.Anything, "ch-1", "fallback order", expectedMessage).
+		Return(nil)
+	repo.On("CreateOrder", mock.Anything, order).
+		Return(nil)
+
+	uc := usecase.NewCreateOrder(repo, tc, tagRoleMap)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 


### PR DESCRIPTION
## Summary
- Fix Discord interaction timeout by deferring response before executing slow operations (thread creation + Notion write)
- Fix tag mentions rendering as plain text (`@283pro`) by using Discord role mention format (`<@&ROLE_ID>`)
- Add `TAG_ROLE_MAP` env var for configurable tag-to-Discord-role-ID mapping
- Refactor and simplify command handler patterns

## Changes
- `respond.go`: Add `respondDeferred` and `editDeferredResponse` helpers
- `new_order_handler.go`: Use deferred response pattern in `/neworder`
- `config.go`: Add `TagRoleMap` field with `parseTagRoleMap` parser
- `create_order.go`: Use `<@&ROLE_ID>` format when role ID is available, fallback to `@tag`
- `main.go`: Wire `TAG_ROLE_MAP` config to use case
- `CLAUDE.md`: Document new env var

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (9 create_order tests, 4 config tests)
- [ ] Manual test: run `/neworder` in Discord — should show "thinking..." indicator, then success message
- [ ] Manual test: verify tag mentions ping the correct Discord role
- [ ] Set `TAG_ROLE_MAP` env var with actual role IDs from Discord server settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)