### PR TITLE
fix: allow role mentions in thread messages

### DIFF
--- a/gateway/discord/thread_creator.go
+++ b/gateway/discord/thread_creator.go
@@ -11,8 +11,8 @@ type threadSession interface {
 	ThreadStartComplex(
 		channelID string, data *discordgo.ThreadStart, options ...discordgo.RequestOption,
 	) (*discordgo.Channel, error)
-	ChannelMessageSend(
-		channelID string, content string, options ...discordgo.RequestOption,
+	ChannelMessageSendComplex(
+		channelID string, data *discordgo.MessageSend, options ...discordgo.RequestOption,
 	) (*discordgo.Message, error)
 }
 
@@ -35,7 +35,12 @@ func (tc *ThreadCreator) CreateThread(_ context.Context, channelID string, name 
 	}
 
 	if message != "" {
-		_, err = tc.s.ChannelMessageSend(thread.ID, message)
+		_, err = tc.s.ChannelMessageSendComplex(thread.ID, &discordgo.MessageSend{
+			Content: message,
+			AllowedMentions: &discordgo.MessageAllowedMentions{
+				Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeRoles},
+			},
+		})
 		if err != nil {
 			return fmt.Errorf("error sending thread message: %w", err)
 		}


### PR DESCRIPTION
## Summary
- `ChannelMessageSend` suppresses role mentions by default in Discord API
- Switch to `ChannelMessageSendComplex` with `AllowedMentions{Parse: [Roles]}` so `<@&ROLE_ID>` tags actually ping Discord roles in thread messages

## Changes
- `gateway/discord/thread_creator.go`: Replace `ChannelMessageSend` with `ChannelMessageSendComplex` + `AllowedMentions`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint` passes
- [ ] Manual test: run `/neworder` with a tag — verify the role is actually pinged in the thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)