### PR TITLE
fix: round TWD amount to nearest whole number

### DIFF
--- a/usecase/register_buy_record.go
+++ b/usecase/register_buy_record.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/xgnid-tw/gx5/domain"
 	"github.com/xgnid-tw/gx5/port"
@@ -28,7 +29,7 @@ func (uc *RegisterBuyRecord) Execute(
 		return fmt.Errorf("get user by discord id: %w", err)
 	}
 
-	twdAmount := jpyAmount * uc.jpyToTWDRate
+	twdAmount := math.Round(jpyAmount * uc.jpyToTWDRate)
 
 	tx := domain.Transaction{
 		ItemName:   itemName,

--- a/usecase/register_buy_record_test.go
+++ b/usecase/register_buy_record_test.go
@@ -89,3 +89,24 @@ func TestRegisterBuyRecord_ExchangeRate(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestRegisterBuyRecord_TWDRounded(t *testing.T) {
+	userRepo := mocks.NewUserRepository(t)
+	txRepo := mocks.NewTransactionRepository(t)
+
+	user := &domain.User{
+		DiscordID: "111", Name: "Alice",
+		NotionID: "abc-db", Currency: domain.CurrencyJPY,
+	}
+
+	// 3500 * 0.217 = 759.5 → rounds to 760
+	userRepo.On("GetUserByDiscordID", mock.Anything, "111").Return(user, nil)
+	txRepo.On("CreateTransaction", mock.Anything, mock.MatchedBy(func(tx domain.Transaction) bool {
+		return tx.JPYAmount == 3500 && tx.TWDAmount == 760
+	})).Return(nil)
+
+	uc := usecase.NewRegisterBuyRecord(userRepo, txRepo, 0.217)
+	err := uc.Execute(context.Background(), "111", 3500, "Item")
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- `JPY × exchange rate` can produce decimals (e.g. 3500 × 0.217 = 759.5)
- Add `math.Round` to produce whole numbers for the Notion 台幣 field

## Changes
- `usecase/register_buy_record.go`: Wrap TWD calculation with `math.Round`
- `usecase/register_buy_record_test.go`: Add rounding test case (759.5 → 760)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint` passes
- [ ] Manual test: register a buy with an amount that produces a decimal TWD, verify Notion shows a whole number

🤖 Generated with [Claude Code](https://claude.com/claude-code)