### PR TITLE
fix: add missing env vars to CI .env generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,16 @@ jobs:
           name: Create env
           command: |
             echo "DISCORD_TOKEN=${DISCORD_TOKEN}" >> .env
+            echo "DISCORD_APP_ID=${DISCORD_APP_ID}" >> .env
+            echo "DISCORD_GUILD_LOG_CHANNEL_ID=${DISCORD_GUILD_LOG_CHANNEL_ID}" >> .env
             echo "NOTION_TOKEN=${NOTION_TOKEN}" >> .env
             echo "NOTION_USER_DB_ID=${NOTION_USER_DB_ID}" >> .env
             echo "NOTION_OTHERS_DB_ID=${NOTION_OTHERS_DB_ID}" >> .env
-            echo "DISCORD_GUILD_LOG_CHANNEL_ID=${DISCORD_GUILD_LOG_CHANNEL_ID}" >> .env
+            echo "NOTION_ORDER_DB_ID=${NOTION_ORDER_DB_ID}" >> .env
+            echo "EXCHANGE_RATE_JPY_TWD=${EXCHANGE_RATE_JPY_TWD}" >> .env
+            echo "TAG_ROLE_MAP=${TAG_ROLE_MAP}" >> .env
             echo "WORKER_CORNTAB=${WORKER_CORNTAB}" >> .env
+            echo "DEBUG=${DEBUG}" >> .env
       - persist_to_workspace:
           root: ./
           paths:


### PR DESCRIPTION
## Summary
- CI `.env` generation was missing env vars added by UC-002 and UC-003, causing the deployed bot to crash on startup
- Added: `DISCORD_APP_ID`, `NOTION_ORDER_DB_ID`, `EXCHANGE_RATE_JPY_TWD`, `TAG_ROLE_MAP`, `DEBUG`

## Action required
Add these env vars in **CircleCI project settings** before merging:
- `DISCORD_APP_ID`
- `NOTION_ORDER_DB_ID`
- `EXCHANGE_RATE_JPY_TWD`
- `TAG_ROLE_MAP`
- `DEBUG` (optional, set `0` or leave empty)

## Test plan
- [ ] Verify env vars are set in CircleCI
- [ ] Merge and deploy
- [ ] Verify bot starts without config errors
- [ ] Test `/neworder` — should show "thinking..." then success, with role mention pinging

🤖 Generated with [Claude Code](https://claude.com/claude-code)