### PR TITLE
docs: fix design doc inconsistencies with implementation

### DIFF
--- a/designDocs/defination/tables/TBL-004_Order_List_Database.md
+++ b/designDocs/defination/tables/TBL-004_Order_List_Database.md
@@ -71,8 +71,8 @@ Tracks group purchase order threads. Each row represents an order with its deadl
 
 ## 5. Usage
 
-- Not currently referenced in application code
-- Serves as a standalone order tracking database in Notion
+- Written by `gateway/notion/order_repository.go` → `CreateOrder()` (UC-002)
+- Records are created when the bot operator executes the `/newOrder` slash command
 
 ---
 

--- a/designDocs/defination/usecases/UC-002_Create_New_Order.md
+++ b/designDocs/defination/usecases/UC-002_Create_New_Order.md
@@ -73,7 +73,8 @@ None.
 
 **On success:**
 - A new Discord thread exists in the invoking channel with the title `orderTitle`
-- The thread's first message contains the shop URL, tag mentions, and deadline (BR-008)
+- The thread's first message contains the shop URL, tag mentions (as Discord role mentions via `<@&ROLE_ID>`), and deadline (BR-008)
+- Guild members with the tag's Discord role are added to the thread (BR-016); failure to add individual members is logged but non-fatal
 - A new record exists in the Notion Order List database with `threadName`, `deadline`, and `tags` populated
 
 **On failure:**
@@ -90,10 +91,12 @@ None.
 1. User executes `/newOrder orderTitle deadline shopURL tags` in a Discord channel (all parameters required)
 2. Discord enforces command visibility to administrators only (BR-015)
 3. Discord enforces all required parameters are present (BR-007)
-4. System creates a new Discord thread in the current channel with title `orderTitle`
-5. System sends the first message in the thread with the format defined in BR-008
-6. System inserts a new record into the Notion Order List database (TBL-004) with `threadName` = `orderTitle`, `deadline` = `deadline`, `tags` = `tags` (BR-009)
-7. System responds to the slash command interaction confirming success
+4. System sends a deferred interaction response (Discord shows "thinking..." indicator)
+5. System creates a new Discord thread in the current channel with title `orderTitle`
+6. System sends the first message in the thread with the format defined in BR-008
+7. System adds guild members with the tag's Discord role to the thread (BR-016)
+8. System inserts a new record into the Notion Order List database (TBL-004) with `threadName` = `orderTitle`, `deadline` = `deadline`, `tags` = `tags` (BR-009)
+9. System edits the deferred response confirming success
 
 ### Detailed Business Flows
 
@@ -110,6 +113,7 @@ At this time, no specific business usage calling this function has been identifi
 | BR-009 | Notion Record Mapping | The Notion record maps as follows: `threadName` ← `orderTitle` (Title), `deadline` ← `deadline` (Date, ISO-8601), `tags` ← `tags` (Select, single value) | `shopURL` is not stored in Notion (TBL-004 has no such column) |
 | BR-010 | Tag Values | Tag must correspond to a valid select option defined in TBL-004: `315pro`, `学マス`, `283pro`, `346pro`, `765pro` (single value only) | Unknown tag is passed as-is; Notion API will reject invalid values |
 | BR-015 | Operator Authorization | Command visibility is restricted via Discord's `DefaultMemberPermissions` (Administrator). Only server administrators can see and execute this command. | Fine-tune per-user/per-role in Discord Server Settings → Integrations → Bot → Command Permissions |
+| BR-016 | Auto-add Tag Members | After thread creation, guild members who have the tag's Discord role (mapped via `TAG_ROLE_MAP` env var) are automatically added to the thread. Failure to add individual members is logged but does not block order creation. | Requires Server Members Intent and `DISCORD_GUILD_ID` env var |
 
 ---
 

--- a/designDocs/defination/usecases/UC-003_Register_Buy_Record.md
+++ b/designDocs/defination/usecases/UC-003_Register_Buy_Record.md
@@ -76,9 +76,9 @@ None.
 
 **On success:**
 - A new record exists in the target member's TBL-002 with:
-  - `品項` = thread title
+  - `品項` = user-provided item name (defaults to thread title)
   - `日幣` = user-input JPY amount
-  - `台幣` = JPY amount × 0.24
+  - `台幣` = round(JPY amount × `EXCHANGE_RATE_JPY_TWD`) — rounded to nearest whole number (BR-011)
   - `付款狀況` = `尚未付款`
 - The bot has replied "登記完畢" in the thread
 
@@ -100,7 +100,7 @@ None.
 5. System looks up the target member in TBL-001 by matching `discord_id`
 6. System retrieves the target member's `notion_id` (TBL-002 database ID)
 7. System retrieves the current thread title from Discord
-8. System calculates TWD amount = JPY amount × 0.24 (BR-011)
+8. System calculates TWD amount = round(JPY amount × `EXCHANGE_RATE_JPY_TWD`) (BR-011)
 9. System inserts a new record into the target member's TBL-002 (BR-012, BR-013)
 10. System replies "登記完畢" in the thread
 
@@ -114,7 +114,7 @@ At this time, no specific business usage calling this function has been identifi
 
 | ID | Rule Name | Description | Exception |
 |---|---|---|---|
-| BR-011 | Fixed Exchange Rate | TWD amount is calculated as `JPY amount × EXCHANGE_RATE_JPY_TWD`; the exchange rate is loaded from the `EXCHANGE_RATE_JPY_TWD` environment variable | None |
+| BR-011 | Fixed Exchange Rate | TWD amount is calculated as `round(JPY amount × EXCHANGE_RATE_JPY_TWD)`; the exchange rate is loaded from the `EXCHANGE_RATE_JPY_TWD` environment variable; result is rounded to the nearest whole number | None |
 | BR-012 | Item Name from Thread Title | The `品項` column is populated with a user-provided item name from the modal. If empty, defaults to the Discord thread title | None |
 | BR-013 | Default Payment Status | New records are always created with `付款狀況` = `尚未付款` (unpaid) | None |
 | BR-014 | Target Member Lookup | The target member is identified by the Discord ID of the replied-to message author; this ID is matched against `discord_id` in TBL-001 to resolve the member's `notion_id` (TBL-002 database ID) | If the replied-to user is not found in TBL-001, the operation fails with an error |

--- a/designDocs/defination/usecases/Use_Case_Index.md
+++ b/designDocs/defination/usecases/Use_Case_Index.md
@@ -5,7 +5,7 @@
 | Actor | Type | Description |
 |---|---|---|
 | Scheduler | System | Cron-based trigger that initiates periodic jobs |
-| Bot Operator | Human | The authorized Discord user (configured via `DISCORD_OWNER_ID` env var) who manages group purchases |
+| Bot Operator | Human | Discord user with Administrator permission who manages group purchases (enforced via `DefaultMemberPermissions`) |
 | Guild Member | Human | Discord user who interacts with the bot via slash commands |
 | Notion API | External System | Data source for user records and transaction data |
 | Discord API | External System | Delivery channel for user notifications, logging, and thread management |


### PR DESCRIPTION
## Summary
- Align design docs with current implementation after UC-002/UC-003 changes

## Changes
| File | Fix |
|---|---|
| `Use_Case_Index.md` | Replace stale `DISCORD_OWNER_ID` reference with `DefaultMemberPermissions (Administrator)` |
| `TBL-004_Order_List_Database.md` | Update §5 Usage: now referenced by `order_repository.go` |
| `UC-002_Create_New_Order.md` | Add deferred response flow, BR-016 (auto-add tag role members to thread), role mention format `<@&ROLE_ID>` |
| `UC-003_Register_Buy_Record.md` | Fix hardcoded `× 0.24` to `EXCHANGE_RATE_JPY_TWD` env var in post-conditions/flow, add TWD rounding to BR-011 |

## Test plan
- [x] Documentation-only change, no code affected
- [x] Lint and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)