### PR TITLE
feat: add members to thread with system message cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           command: |
             echo "DISCORD_TOKEN=${DISCORD_TOKEN}" >> .env
             echo "DISCORD_APP_ID=${DISCORD_APP_ID}" >> .env
+            echo "DISCORD_GUILD_ID=${DISCORD_GUILD_ID}" >> .env
             echo "DISCORD_GUILD_LOG_CHANNEL_ID=${DISCORD_GUILD_LOG_CHANNEL_ID}" >> .env
             echo "NOTION_TOKEN=${NOTION_TOKEN}" >> .env
             echo "NOTION_USER_DB_ID=${NOTION_USER_DB_ID}" >> .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ Dependency rule: `gateway` → `domain`, `usecase` → `port` → `domain`. No l
 |---|---|
 | `DISCORD_TOKEN` | Discord bot token |
 | `DISCORD_APP_ID` | Discord application ID (for slash command registration) |
+| `DISCORD_GUILD_ID` | Discord guild (server) ID |
 | `DISCORD_GUILD` | Guild name (informational) |
 | `DISCORD_GUILD_LOG_CHANNEL_ID` | Channel ID for logging |
 | `NOTION_TOKEN` | Notion API token |

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	NotionOrderDBID     string
 	DiscordToken        string
 	DiscordAppID        string
+	DiscordGuildID      string
 	DiscordLogChannelID string
 	ExchangeRateJPYTWD  float64
 	WorkerCrontab       string
@@ -29,6 +30,7 @@ func Load() (Config, error) {
 		NotionOrderDBID:     os.Getenv("NOTION_ORDER_DB_ID"),
 		DiscordToken:        os.Getenv("DISCORD_TOKEN"),
 		DiscordAppID:        os.Getenv("DISCORD_APP_ID"),
+		DiscordGuildID:      os.Getenv("DISCORD_GUILD_ID"),
 		DiscordLogChannelID: os.Getenv("DISCORD_GUILD_LOG_CHANNEL_ID"),
 		WorkerCrontab:       os.Getenv("WORKER_CORNTAB"),
 		Debug:               os.Getenv("DEBUG") == "1",
@@ -60,6 +62,10 @@ func Load() (Config, error) {
 
 	if cfg.DiscordAppID == "" {
 		return Config{}, fmt.Errorf("DISCORD_APP_ID is required")
+	}
+
+	if cfg.DiscordGuildID == "" {
+		return Config{}, fmt.Errorf("DISCORD_GUILD_ID is required")
 	}
 
 	if cfg.DiscordLogChannelID == "" {

--- a/designDocs/defination/usecases/UC-002_Create_New_Order.md
+++ b/designDocs/defination/usecases/UC-002_Create_New_Order.md
@@ -94,9 +94,9 @@ None.
 4. System sends a deferred interaction response (Discord shows "thinking..." indicator)
 5. System creates a new Discord thread in the current channel with title `orderTitle`
 6. System sends the first message in the thread with the format defined in BR-008
-7. System adds guild members with the tag's Discord role to the thread (BR-016)
-8. System inserts a new record into the Notion Order List database (TBL-004) with `threadName` = `orderTitle`, `deadline` = `deadline`, `tags` = `tags` (BR-009)
-9. System edits the deferred response confirming success
+7. System inserts a new record into the Notion Order List database (TBL-004) with `threadName` = `orderTitle`, `deadline` = `deadline`, `tags` = `tags` (BR-009)
+8. System edits the deferred response confirming success
+9. In the background: system adds guild members with the tag's Discord role to the thread, then deletes the "added to thread" system messages (BR-016)
 
 ### Detailed Business Flows
 
@@ -113,7 +113,7 @@ At this time, no specific business usage calling this function has been identifi
 | BR-009 | Notion Record Mapping | The Notion record maps as follows: `threadName` ← `orderTitle` (Title), `deadline` ← `deadline` (Date, ISO-8601), `tags` ← `tags` (Select, single value) | `shopURL` is not stored in Notion (TBL-004 has no such column) |
 | BR-010 | Tag Values | Tag must correspond to a valid select option defined in TBL-004: `315pro`, `学マス`, `283pro`, `346pro`, `765pro` (single value only) | Unknown tag is passed as-is; Notion API will reject invalid values |
 | BR-015 | Operator Authorization | Command visibility is restricted via Discord's `DefaultMemberPermissions` (Administrator). Only server administrators can see and execute this command. | Fine-tune per-user/per-role in Discord Server Settings → Integrations → Bot → Command Permissions |
-| BR-016 | Auto-add Tag Members | After thread creation, guild members who have the tag's Discord role (mapped via `TAG_ROLE_MAP` env var) are automatically added to the thread. Failure to add individual members is logged but does not block order creation. | Requires Server Members Intent and `DISCORD_GUILD_ID` env var |
+| BR-016 | Auto-add Tag Members | After thread creation, guild members who have the tag's Discord role (mapped via `TAG_ROLE_MAP` env var) are automatically added to the thread in a background goroutine. System messages ("X added Y to thread") are deleted after all members are added (requires Manage Messages permission). Failure to add individual members is logged but does not block order creation. | Requires Server Members Intent, `DISCORD_GUILD_ID` env var, and Manage Messages bot permission |
 
 ---
 

--- a/gateway/discord/member_adder.go
+++ b/gateway/discord/member_adder.go
@@ -1,0 +1,107 @@
+package discord
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"slices"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type memberAdderSession interface {
+	GuildMembers(
+		guildID string, after string, limit int, options ...discordgo.RequestOption,
+	) ([]*discordgo.Member, error)
+	ThreadMemberAdd(threadID, memberID string, options ...discordgo.RequestOption) error
+	ChannelMessages(
+		channelID string, limit int, beforeID, afterID, aroundID string,
+		options ...discordgo.RequestOption,
+	) ([]*discordgo.Message, error)
+	ChannelMessageDelete(
+		channelID, messageID string, options ...discordgo.RequestOption,
+	) error
+}
+
+// MemberAdder implements port.MemberAdder using the Discord API.
+type MemberAdder struct {
+	s       memberAdderSession
+	guildID string
+}
+
+func NewMemberAdder(s *discordgo.Session, guildID string) *MemberAdder {
+	return &MemberAdder{s: s, guildID: guildID}
+}
+
+func (ma *MemberAdder) AddRoleMembersToThread(
+	_ context.Context, threadID string, roleID string,
+) error {
+	members, err := ma.fetchMembersWithRole(roleID)
+	if err != nil {
+		return fmt.Errorf("fetch members with role %s: %w", roleID, err)
+	}
+
+	for _, m := range members {
+		err = ma.s.ThreadMemberAdd(threadID, m.User.ID)
+		if err != nil {
+			log.Printf("failed to add member %s to thread %s: %s", m.User.ID, threadID, err)
+		}
+	}
+
+	ma.deleteSystemMessages(threadID)
+
+	return nil
+}
+
+const (
+	recentMessageLimit         = 50
+	messageTypeRecipientAdd    = 1
+	messageTypeGuildMemberJoin = 7
+)
+
+func (ma *MemberAdder) deleteSystemMessages(threadID string) {
+	messages, err := ma.s.ChannelMessages(threadID, recentMessageLimit, "", "", "")
+	if err != nil {
+		log.Printf("failed to fetch messages for cleanup in thread %s: %s", threadID, err)
+		return
+	}
+
+	for _, msg := range messages {
+		if msg.Type == discordgo.MessageType(messageTypeRecipientAdd) ||
+			msg.Type == discordgo.MessageType(messageTypeGuildMemberJoin) {
+			delErr := ma.s.ChannelMessageDelete(threadID, msg.ID)
+			if delErr != nil {
+				log.Printf("failed to delete system message %s: %s", msg.ID, delErr)
+			}
+		}
+	}
+}
+
+func (ma *MemberAdder) fetchMembersWithRole(roleID string) ([]*discordgo.Member, error) {
+	var result []*discordgo.Member
+
+	after := ""
+
+	const pageSize = 100
+
+	for {
+		members, err := ma.s.GuildMembers(ma.guildID, after, pageSize)
+		if err != nil {
+			return nil, fmt.Errorf("guild members: %w", err)
+		}
+
+		for _, m := range members {
+			if slices.Contains(m.Roles, roleID) {
+				result = append(result, m)
+			}
+		}
+
+		if len(members) < pageSize {
+			break
+		}
+
+		after = members[len(members)-1].User.ID
+	}
+
+	return result, nil
+}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,8 @@ func main() {
 
 	orderRepo := notiongw.NewOrderRepository(notionClient.Page, cfg.NotionOrderDBID)
 	threadCreator := discordgw.NewThreadCreator(dc)
-	createOrderUC := usecase.NewCreateOrder(orderRepo, threadCreator, cfg.TagRoleMap)
+	memberAdder := discordgw.NewMemberAdder(dc, cfg.DiscordGuildID)
+	createOrderUC := usecase.NewCreateOrder(orderRepo, threadCreator, memberAdder, cfg.TagRoleMap)
 
 	txRepo := notiongw.NewTransactionRepository(notionClient.Page)
 	buyUC := usecase.NewRegisterBuyRecord(repo, txRepo, cfg.ExchangeRateJPYTWD)

--- a/mocks/MemberAdder.go
+++ b/mocks/MemberAdder.go
@@ -1,0 +1,48 @@
+// Code generated manually. DO NOT EDIT.
+
+package mocks
+
+import (
+	context "context"
+
+	mock "github.com/stretchr/testify/mock"
+)
+
+// MemberAdder is a mock type for the MemberAdder type.
+type MemberAdder struct {
+	mock.Mock
+}
+
+// AddRoleMembersToThread provides a mock function with given fields: ctx, threadID, roleID.
+func (_m *MemberAdder) AddRoleMembersToThread(
+	ctx context.Context, threadID string, roleID string,
+) error {
+	ret := _m.Called(ctx, threadID, roleID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddRoleMembersToThread")
+	}
+
+	var r0 error
+
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, threadID, roleID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// NewMemberAdder creates a new instance of MemberAdder.
+func NewMemberAdder(t interface {
+	mock.TestingT
+	Cleanup(func())
+}) *MemberAdder {
+	mock := &MemberAdder{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}

--- a/port/member_adder.go
+++ b/port/member_adder.go
@@ -1,0 +1,8 @@
+package port
+
+import "context"
+
+// MemberAdder adds guild members with a specific role to a thread.
+type MemberAdder interface {
+	AddRoleMembersToThread(ctx context.Context, threadID string, roleID string) error
+}

--- a/usecase/create_order.go
+++ b/usecase/create_order.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/xgnid-tw/gx5/domain"
@@ -12,15 +13,18 @@ import (
 type CreateOrder struct {
 	repo          port.OrderRepository
 	threadCreator port.ThreadCreator
+	memberAdder   port.MemberAdder
 	tagRoleMap    map[string]string
 }
 
 func NewCreateOrder(
-	repo port.OrderRepository, threadCreator port.ThreadCreator, tagRoleMap map[string]string,
+	repo port.OrderRepository, threadCreator port.ThreadCreator,
+	memberAdder port.MemberAdder, tagRoleMap map[string]string,
 ) *CreateOrder {
 	return &CreateOrder{
 		repo:          repo,
 		threadCreator: threadCreator,
+		memberAdder:   memberAdder,
 		tagRoleMap:    tagRoleMap,
 	}
 }
@@ -34,9 +38,21 @@ func (uc *CreateOrder) Execute(
 
 	message := buildThreadMessage(order, uc.tagRoleMap)
 
-	_, err := uc.threadCreator.CreateThread(ctx, channelID, order.ThreadName, message)
+	threadID, err := uc.threadCreator.CreateThread(ctx, channelID, order.ThreadName, message)
 	if err != nil {
 		return fmt.Errorf("create thread: %w", err)
+	}
+
+	if order.Tag != "" {
+		if roleID, ok := uc.tagRoleMap[string(order.Tag)]; ok && uc.memberAdder != nil {
+			//nolint:contextcheck,gosec,nolintlint // intentionally detached from caller context
+			go func() {
+				addErr := uc.memberAdder.AddRoleMembersToThread(context.Background(), threadID, roleID)
+				if addErr != nil {
+					log.Printf("add role members to thread: %s", addErr)
+				}
+			}()
+		}
 	}
 
 	err = uc.repo.CreateOrder(ctx, order)

--- a/usecase/create_order_test.go
+++ b/usecase/create_order_test.go
@@ -17,7 +17,7 @@ func TestCreateOrder_MissingOrderTitle(t *testing.T) {
 	repo := mocks.NewOrderRepository(t)
 	tc := mocks.NewThreadCreator(t)
 
-	uc := usecase.NewCreateOrder(repo, tc, nil)
+	uc := usecase.NewCreateOrder(repo, tc, nil, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", domain.Order{})
 
@@ -32,7 +32,7 @@ func TestCreateOrder_ThreadCreationError(t *testing.T) {
 	tc.On("CreateThread", mock.Anything, "ch-1", "test order", mock.Anything).
 		Return("", errors.New("discord error"))
 
-	uc := usecase.NewCreateOrder(repo, tc, nil)
+	uc := usecase.NewCreateOrder(repo, tc, nil, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", domain.Order{
 		ThreadName: "test order",
@@ -51,7 +51,7 @@ func TestCreateOrder_NotionError(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, domain.Order{ThreadName: "test order"}).
 		Return(errors.New("notion error"))
 
-	uc := usecase.NewCreateOrder(repo, tc, nil)
+	uc := usecase.NewCreateOrder(repo, tc, nil, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", domain.Order{
 		ThreadName: "test order",
@@ -64,6 +64,7 @@ func TestCreateOrder_NotionError(t *testing.T) {
 func TestCreateOrder_Success_AllFields(t *testing.T) {
 	repo := mocks.NewOrderRepository(t)
 	tc := mocks.NewThreadCreator(t)
+	ma := mocks.NewMemberAdder(t)
 
 	order := domain.Order{
 		ThreadName: "test order",
@@ -77,10 +78,11 @@ func TestCreateOrder_Success_AllFields(t *testing.T) {
 
 	tc.On("CreateThread", mock.Anything, "ch-1", "test order", expectedMessage).
 		Return("thread-id", nil)
+	ma.On("AddRoleMembersToThread", mock.Anything, "thread-id", "123456").Return(nil).Maybe()
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc, tagRoleMap)
+	uc := usecase.NewCreateOrder(repo, tc, ma, tagRoleMap)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -100,7 +102,7 @@ func TestCreateOrder_Success_OnlyTitle(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc, nil)
+	uc := usecase.NewCreateOrder(repo, tc, nil, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -123,7 +125,7 @@ func TestCreateOrder_Success_PartialFields(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc, nil)
+	uc := usecase.NewCreateOrder(repo, tc, nil, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -146,7 +148,7 @@ func TestCreateOrder_Success_ShopURLOnly(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc, nil)
+	uc := usecase.NewCreateOrder(repo, tc, nil, nil)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -156,6 +158,7 @@ func TestCreateOrder_Success_ShopURLOnly(t *testing.T) {
 func TestCreateOrder_Success_TagOnly(t *testing.T) {
 	repo := mocks.NewOrderRepository(t)
 	tc := mocks.NewThreadCreator(t)
+	ma := mocks.NewMemberAdder(t)
 
 	order := domain.Order{
 		ThreadName: "tag order",
@@ -167,10 +170,11 @@ func TestCreateOrder_Success_TagOnly(t *testing.T) {
 
 	tc.On("CreateThread", mock.Anything, "ch-1", "tag order", expectedMessage).
 		Return("thread-id", nil)
+	ma.On("AddRoleMembersToThread", mock.Anything, "thread-id", "789012").Return(nil).Maybe()
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc, tagRoleMap)
+	uc := usecase.NewCreateOrder(repo, tc, ma, tagRoleMap)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 
@@ -194,7 +198,7 @@ func TestCreateOrder_Success_TagWithoutRoleID(t *testing.T) {
 	repo.On("CreateOrder", mock.Anything, order).
 		Return(nil)
 
-	uc := usecase.NewCreateOrder(repo, tc, tagRoleMap)
+	uc := usecase.NewCreateOrder(repo, tc, nil, tagRoleMap)
 
 	err := uc.Execute(context.Background(), "ch-1", order)
 


### PR DESCRIPTION
## Summary
- Re-add `MemberAdder` to add tag role members to thread (matching manual thread creation behavior)
- After adding all members, delete the "X added Y to thread" system messages for clean UX
- Runs in background goroutine to avoid blocking `/neworder` response

## Flow
1. `/neworder` responds immediately
2. Background: add each role member via `ThreadMemberAdd`
3. Background: fetch recent messages, delete system messages (type 1 + 7)

## New bot permission required
- **Manage Messages** — needed to delete system messages in threads

## New env var
- `DISCORD_GUILD_ID` — add to CircleCI and `.env`

## Changes
- `port/member_adder.go`: Re-add interface
- `gateway/discord/member_adder.go`: Implementation with `deleteSystemMessages` cleanup
- `mocks/MemberAdder.go`: Mock
- `usecase/create_order.go`: Wire MemberAdder with async goroutine
- `config/config.go`: Re-add `DISCORD_GUILD_ID`
- `main.go`, `.circleci/config.yml`, `CLAUDE.md`: Wiring and docs

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint` passes
- [ ] Manual: `/neworder` with tag — members added, system messages cleaned up
- [ ] Verify bot has **Manage Messages** permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)