### PR TITLE
feat: show user mention, amount, and item name in buy confirmation

### DIFF
--- a/domain/transaction.go
+++ b/domain/transaction.go
@@ -7,3 +7,10 @@ type Transaction struct {
 	TWDAmount  float64 // 台幣: JPY × exchange rate
 	DatabaseID string  // target member's TBL-002 database ID (from TBL-001 notion_id)
 }
+
+// BuyResult contains the result of a successful buy record registration.
+type BuyResult struct {
+	DisplayAmount float64
+	Currency      Currency
+	ItemName      string
+}

--- a/gateway/discord/command/buy_command.go
+++ b/gateway/discord/command/buy_command.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 
+	"github.com/xgnid-tw/gx5/domain"
 	"github.com/xgnid-tw/gx5/port"
 )
 
@@ -134,7 +135,7 @@ func handleBuyModal(
 		return
 	}
 
-	err = uc.Execute(context.Background(), targetDiscordID, jpyAmount, itemName)
+	result, err := uc.Execute(context.Background(), targetDiscordID, jpyAmount, itemName)
 	if err != nil {
 		log.Printf("register buy record failed: %s", err)
 		respondError(s, i, "登記失敗")
@@ -142,5 +143,14 @@ func handleBuyModal(
 		return
 	}
 
-	respondSuccess(s, i, "登記完畢")
+	respondSuccess(s, i, formatBuyResult(targetDiscordID, result))
+}
+
+func formatBuyResult(discordID string, r *domain.BuyResult) string {
+	symbol := "NT$"
+	if r.Currency == domain.CurrencyJPY {
+		symbol = "¥"
+	}
+
+	return fmt.Sprintf("登記完畢 <@%s> %s%.0f (%s)", discordID, symbol, r.DisplayAmount, r.ItemName)
 }

--- a/port/buy_record.go
+++ b/port/buy_record.go
@@ -1,8 +1,14 @@
 package port
 
-import "context"
+import (
+	"context"
+
+	"github.com/xgnid-tw/gx5/domain"
+)
 
 // BuyRecordRegisterer abstracts the register-buy-record use case for the gateway layer.
 type BuyRecordRegisterer interface {
-	Execute(ctx context.Context, targetDiscordID string, jpyAmount float64, itemName string) error
+	Execute(
+		ctx context.Context, targetDiscordID string, jpyAmount float64, itemName string,
+	) (*domain.BuyResult, error)
 }

--- a/usecase/register_buy_record.go
+++ b/usecase/register_buy_record.go
@@ -23,10 +23,10 @@ func NewRegisterBuyRecord(
 
 func (uc *RegisterBuyRecord) Execute(
 	ctx context.Context, targetDiscordID string, jpyAmount float64, itemName string,
-) error {
+) (*domain.BuyResult, error) {
 	user, err := uc.userRepo.GetUserByDiscordID(ctx, targetDiscordID)
 	if err != nil {
-		return fmt.Errorf("get user by discord id: %w", err)
+		return nil, fmt.Errorf("get user by discord id: %w", err)
 	}
 
 	twdAmount := math.Round(jpyAmount * uc.jpyToTWDRate)
@@ -40,8 +40,17 @@ func (uc *RegisterBuyRecord) Execute(
 
 	err = uc.txRepo.CreateTransaction(ctx, tx)
 	if err != nil {
-		return fmt.Errorf("create transaction: %w", err)
+		return nil, fmt.Errorf("create transaction: %w", err)
 	}
 
-	return nil
+	displayAmount := twdAmount
+	if user.Currency == domain.CurrencyJPY {
+		displayAmount = jpyAmount
+	}
+
+	return &domain.BuyResult{
+		DisplayAmount: displayAmount,
+		Currency:      user.Currency,
+		ItemName:      itemName,
+	}, nil
 }

--- a/usecase/register_buy_record_test.go
+++ b/usecase/register_buy_record_test.go
@@ -31,9 +31,37 @@ func TestRegisterBuyRecord_Success(t *testing.T) {
 	}).Return(nil)
 
 	uc := usecase.NewRegisterBuyRecord(userRepo, txRepo, 0.24)
-	err := uc.Execute(context.Background(), "111", 3000, "Thread Title")
+	result, err := uc.Execute(context.Background(), "111", 3000, "Thread Title")
 
 	require.NoError(t, err)
+	require.Equal(t, float64(3000), result.DisplayAmount)
+	require.Equal(t, domain.CurrencyJPY, result.Currency)
+	require.Equal(t, "Thread Title", result.ItemName)
+}
+
+func TestRegisterBuyRecord_Success_TWDUser(t *testing.T) {
+	userRepo := mocks.NewUserRepository(t)
+	txRepo := mocks.NewTransactionRepository(t)
+
+	user := &domain.User{
+		DiscordID: "222", Name: "Bob",
+		NotionID: "bob-db", Currency: domain.CurrencyTWD,
+	}
+
+	userRepo.On("GetUserByDiscordID", mock.Anything, "222").Return(user, nil)
+	txRepo.On("CreateTransaction", mock.Anything, domain.Transaction{
+		ItemName:   "Item",
+		JPYAmount:  3000,
+		TWDAmount:  720,
+		DatabaseID: "bob-db",
+	}).Return(nil)
+
+	uc := usecase.NewRegisterBuyRecord(userRepo, txRepo, 0.24)
+	result, err := uc.Execute(context.Background(), "222", 3000, "Item")
+
+	require.NoError(t, err)
+	require.Equal(t, float64(720), result.DisplayAmount)
+	require.Equal(t, domain.CurrencyTWD, result.Currency)
 }
 
 func TestRegisterBuyRecord_UserNotFound(t *testing.T) {
@@ -44,9 +72,10 @@ func TestRegisterBuyRecord_UserNotFound(t *testing.T) {
 		Return(nil, errors.New("user not found"))
 
 	uc := usecase.NewRegisterBuyRecord(userRepo, txRepo, 0.24)
-	err := uc.Execute(context.Background(), "999", 3000, "Thread Title")
+	result, err := uc.Execute(context.Background(), "999", 3000, "Thread Title")
 
 	require.Error(t, err)
+	require.Nil(t, result)
 	require.ErrorContains(t, err, "get user by discord id")
 }
 
@@ -64,9 +93,10 @@ func TestRegisterBuyRecord_CreateTransactionError(t *testing.T) {
 		Return(errors.New("notion error"))
 
 	uc := usecase.NewRegisterBuyRecord(userRepo, txRepo, 0.24)
-	err := uc.Execute(context.Background(), "111", 3000, "Thread Title")
+	result, err := uc.Execute(context.Background(), "111", 3000, "Thread Title")
 
 	require.Error(t, err)
+	require.Nil(t, result)
 	require.ErrorContains(t, err, "create transaction")
 }
 
@@ -85,9 +115,10 @@ func TestRegisterBuyRecord_ExchangeRate(t *testing.T) {
 	})).Return(nil)
 
 	uc := usecase.NewRegisterBuyRecord(userRepo, txRepo, 0.24)
-	err := uc.Execute(context.Background(), "111", 10000, "Item")
+	result, err := uc.Execute(context.Background(), "111", 10000, "Item")
 
 	require.NoError(t, err)
+	require.Equal(t, float64(10000), result.DisplayAmount)
 }
 
 func TestRegisterBuyRecord_TWDRounded(t *testing.T) {
@@ -106,7 +137,8 @@ func TestRegisterBuyRecord_TWDRounded(t *testing.T) {
 	})).Return(nil)
 
 	uc := usecase.NewRegisterBuyRecord(userRepo, txRepo, 0.217)
-	err := uc.Execute(context.Background(), "111", 3500, "Item")
+	result, err := uc.Execute(context.Background(), "111", 3500, "Item")
 
 	require.NoError(t, err)
+	require.Equal(t, float64(3500), result.DisplayAmount)
 }


### PR DESCRIPTION
Response changes from "登記完畢" to:
  登記完畢 <@discordID> ¥3,000 (item name)    ← JPY user
  登記完畢 <@discordID> NT$720 (item name)     ← TWD user

- Execute returns *domain.BuyResult with DisplayAmount, Currency, ItemName
- Amount shown matches user's currency from TBL-001