### PR TITLE
Feat/debt reminder command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,10 +127,9 @@ Dependency rule: `gateway` → `domain`, `usecase` → `port` → `domain`. No l
 
 ## Key Design Decisions
 
-- **Scheduling:** gocron with Asia/Tokyo timezone; cron expression from `WORKER_CORNTAB` env var
+- **Scheduling:** gocron with Asia/Tokyo timezone; `/debt-reminder` slash command triggers immediate run + one-shot delayed run
 - **Notification threshold:** Personal DB: per-currency (TWD > 2000, JPY > 8000) defined as `notificationAmountLimit` in `usecase/notify_unpaid.go`; Others DB: any amount > 0
-- **Notification schedule:** Users are notified on the 1st and 15th of each month
-- **Debug mode:** `DEBUG=1` disables actual Discord DMs (logs only) and fakes time to the 1st via `clock.NewMock()`
+- **Debug mode:** `/debt-reminder debug:true` sends reminders to log channel only (no DMs); the delayed run always uses production mode
 - **No channel passing:** use case calls notifier directly; one failure does not block other users (logged, not fatal)
 
 ---
@@ -149,8 +148,6 @@ Dependency rule: `gateway` → `domain`, `usecase` → `port` → `domain`. No l
 | `NOTION_OTHERS_DB_ID` | Notion shared "其他" database ID |
 | `NOTION_ORDER_DB_ID` | Notion Order List database ID (TBL-004) |
 | `EXCHANGE_RATE_JPY_TWD` | JPY to TWD exchange rate (e.g. `0.24`) |
-| `WORKER_CORNTAB` | Cron schedule (e.g. `*/1 * * * *`) |
-| `DEBUG` | Set to `1` to enable debug mode |
 | `TAG_ROLE_MAP` | Comma-separated tag=roleID pairs for Discord role mentions |
 
 ---

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,6 @@ type Config struct {
 	DiscordGuildID      string
 	DiscordLogChannelID string
 	ExchangeRateJPYTWD  float64
-	Debug               bool
 	TagRoleMap          map[string]string
 }
 
@@ -31,7 +30,6 @@ func Load() (Config, error) {
 		DiscordAppID:        os.Getenv("DISCORD_APP_ID"),
 		DiscordGuildID:      os.Getenv("DISCORD_GUILD_ID"),
 		DiscordLogChannelID: os.Getenv("DISCORD_GUILD_LOG_CHANNEL_ID"),
-		Debug:               os.Getenv("DEBUG") == "1",
 	}
 	cfg.TagRoleMap = parseTagRoleMap(os.Getenv("TAG_ROLE_MAP"))
 
@@ -72,10 +70,6 @@ func Load() (Config, error) {
 
 	if cfg.NotionOrderDBID == "" {
 		return Config{}, fmt.Errorf("NOTION_ORDER_DB_ID is required")
-	}
-
-	if cfg.DiscordAppID == "" {
-		return Config{}, fmt.Errorf("DISCORD_APP_ID is required")
 	}
 
 	return cfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,6 @@ type Config struct {
 	DiscordGuildID      string
 	DiscordLogChannelID string
 	ExchangeRateJPYTWD  float64
-	WorkerCrontab       string
 	Debug               bool
 	TagRoleMap          map[string]string
 }
@@ -32,7 +31,6 @@ func Load() (Config, error) {
 		DiscordAppID:        os.Getenv("DISCORD_APP_ID"),
 		DiscordGuildID:      os.Getenv("DISCORD_GUILD_ID"),
 		DiscordLogChannelID: os.Getenv("DISCORD_GUILD_LOG_CHANNEL_ID"),
-		WorkerCrontab:       os.Getenv("WORKER_CORNTAB"),
 		Debug:               os.Getenv("DEBUG") == "1",
 	}
 	cfg.TagRoleMap = parseTagRoleMap(os.Getenv("TAG_ROLE_MAP"))
@@ -70,10 +68,6 @@ func Load() (Config, error) {
 
 	if cfg.DiscordLogChannelID == "" {
 		return Config{}, fmt.Errorf("DISCORD_GUILD_LOG_CHANNEL_ID is required")
-	}
-
-	if cfg.WorkerCrontab == "" {
-		return Config{}, fmt.Errorf("WORKER_CORNTAB is required")
 	}
 
 	if cfg.NotionOrderDBID == "" {

--- a/designDocs/defination/usecases/UC-004_Trigger_Debt_Reminder.md
+++ b/designDocs/defination/usecases/UC-004_Trigger_Debt_Reminder.md
@@ -1,0 +1,163 @@
+# UC-004: Trigger Debt Reminder
+
+## Document Metadata
+
+| Item | Value |
+|---|---|
+| Use Case ID | UC-004 |
+| Use Case Name | Trigger Debt Reminder |
+| Version | 1.0 |
+| Status | Draft |
+| Date | 2026/04/05 |
+| Author | — |
+
+---
+
+## 1. Use Case Overview
+
+### Purpose
+
+Allow the bot operator to manually trigger a debt reminder via a Discord slash command, replacing the previous cron-based automatic reminder (UC-001). The command runs the reminder immediately and schedules a second production run after a configurable number of days.
+
+### Summary
+
+The bot operator executes `/debt-reminder` with optional `days` and `debug` parameters. The system immediately runs the unpaid notification logic — in debug mode (log channel only) or production mode (actual DMs) depending on the `debug` flag. It then schedules a one-shot delayed job to run the same logic in production mode after `days` days, at the same time of day.
+
+### Scope
+
+**In scope:**
+- Parsing slash command parameters (`days`, `debug`)
+- Immediate execution of the unpaid notification logic
+- Scheduling a one-shot delayed execution in production mode
+- Debug mode toggle per invocation (affects immediate run only)
+
+**Out of scope:**
+- Recurring/cron-based scheduling (UC-001 is deprecated by this use case)
+- Cancelling or listing scheduled jobs
+- Modifying notification thresholds or user lists
+
+---
+
+## 2. Actor Information
+
+### Primary Actor
+
+| Actor | Role |
+|---|---|
+| Bot Operator | Discord user with Administrator permission who triggers the reminder |
+
+### Secondary Actor
+
+None.
+
+### System Actor
+
+| System | Role |
+|---|---|
+| Notion API | Data source — provides user list and unpaid transaction records |
+| Discord API | Delivery channel — sends DMs to users and logs to the guild channel |
+| gocron Scheduler | Manages the delayed one-shot job |
+
+---
+
+## 3. Pre-conditions and Post-conditions
+
+### Pre-conditions
+
+- The Discord bot is authenticated and connected to the guild
+- The Notion user database is accessible and contains at least one user record
+- The `/debt-reminder` slash command is registered with the Discord application
+- The invoking user has Administrator permission in the Discord guild (BR-020)
+
+### Post-conditions
+
+**On success:**
+- The unpaid notification logic has executed immediately (debug or production mode per BR-017)
+- A one-shot job is scheduled to execute in production mode after `days` days (BR-018)
+- The operator receives a confirmation message with execution summary
+
+**On failure:**
+- If the immediate run fails → error is reported to the operator; the delayed job is still scheduled
+- If scheduling the delayed job fails → error is reported to the operator; the immediate run has already completed
+- Per-user DM failures are isolated (same as UC-001 BR-004)
+
+---
+
+## 4. Business Flows
+
+### Summary Flow
+
+1. Bot Operator executes `/debt-reminder` in a Discord channel (optionally with `days` and `debug`)
+2. Discord enforces command visibility to administrators only (BR-020)
+3. System sends a deferred interaction response (Discord shows "thinking..." indicator)
+4. System executes the unpaid notification logic immediately:
+   - If `debug=true` → send reminders to log channel only, skip DMs (BR-017)
+   - If `debug=false` → send reminders as DMs and log to guild channel
+5. System schedules a one-shot job to run `days` days from now at the same time, in production mode (BR-018)
+6. System edits the deferred response confirming:
+   - Immediate run result (debug or production, number of users notified)
+   - Scheduled production run date/time
+
+### Detailed Business Flows
+
+At this time, no specific business usage calling this function has been identified; therefore, a detailed business flow definition is not provided.
+
+---
+
+## 5. Business Rules
+
+| ID | Rule Name | Description | Exception |
+|---|---|---|---|
+| BR-017 | Debug Mode (Immediate Run) | When `debug=true`, the immediate run sends reminders to the log channel only (no DMs). The delayed run is always production mode regardless of this flag. | None |
+| BR-018 | Delayed One-Shot Execution | The system schedules a one-shot job to run exactly `days × 24 hours` after the command is issued. The delayed run always uses production mode. | If the bot restarts before the delayed job fires, the job is lost (no persistence) |
+| BR-019 | Default Parameter Values | `days` defaults to 15; `debug` defaults to false | None |
+| BR-020 | Operator Authorization | Command visibility is restricted via Discord's `DefaultMemberPermissions` (Administrator). Only server administrators can see and execute this command. | Fine-tune per-user/per-role in Discord Server Settings → Integrations → Bot → Command Permissions |
+| BR-021 | Notification Thresholds | Same as UC-001: personal DB users notified when unpaid exceeds per-currency threshold (TWD > 2,000, JPY > 8,000); others DB users notified when any unpaid amount exists | None |
+| BR-022 | DM Failure Isolation | A failure to send a DM to one user does not stop the notification process for remaining users (same as UC-001 BR-004) | None |
+
+---
+
+## 6. Related Use Cases
+
+| Use Case | Relationship |
+|---|---|
+| UC-001 Notify Unpaid Users | **Deprecated by** this use case. UC-004 replaces the cron-based trigger with an on-demand slash command. The core notification logic (threshold checks, DM sending) is reused. |
+
+---
+
+## 7. Supplementary Information
+
+### Expected Usage Frequency
+
+- On-demand, triggered by the bot operator
+- Estimated: once or twice per month
+- No peak hours expected
+
+### Operations and Maintenance Requirements
+
+- The `WORKER_CORNTAB` environment variable is no longer required and should be removed from config
+- The day guard (1st/15th check) in `NotifyUnpaid` is removed — the operator controls when to run
+- The `clock` dependency in `NotifyUnpaid` is removed — no longer needed without the day guard
+- Debug mode is now per-invocation (slash command parameter), not a global env var for this use case
+
+### Deprecation: UC-001
+
+The following components are removed:
+- Cron job setup in `main.go`
+- `WORKER_CORNTAB` env var and its config validation
+- Day guard (`day != 1 && day != 15`) in `usecase/notify_unpaid.go`
+- Debug-mode clock faking in `main.go`
+- `clock.Clock` field from `NotifyUnpaid` struct
+
+### Other Notes
+
+- The delayed job is not persisted — if the bot restarts, the scheduled job is lost. This is acceptable for the current use case since the operator can re-issue the command.
+- The `Notifier` must support per-call debug toggling. The `debug` field can be passed as a parameter to `Execute` rather than baked into the notifier at construction.
+
+---
+
+**Revision History**
+
+| Version | Date | Author | Description |
+|---|---|---|---|
+| 1.0 | 2026/04/05 | — | Initial draft |

--- a/designDocs/defination/usecases/Use_Case_Index.md
+++ b/designDocs/defination/usecases/Use_Case_Index.md
@@ -16,7 +16,8 @@
 
 | ID | Use Case Name | Trigger | Primary Actor | Description | Status |
 |---|---|---|---|---|---|
-| [UC-001](UC-001_Notify_Unpaid_Users.md) | Notify Unpaid Users | Cron schedule | Scheduler | Checks each user's unpaid amount in Notion and sends a Discord DM reminder if the total exceeds 2,000 TWD | Draft |
+| [UC-001](UC-001_Notify_Unpaid_Users.md) | Notify Unpaid Users | Cron schedule | Scheduler | **Deprecated by UC-004.** Checks each user's unpaid amount in Notion and sends a Discord DM reminder if the total exceeds 2,000 TWD | Deprecated |
+| [UC-004](UC-004_Trigger_Debt_Reminder.md) | Trigger Debt Reminder | `/debt-reminder` slash command | Bot Operator | Replaces UC-001. Immediately runs unpaid notification (debug or production mode) and schedules a one-shot production run after N days | Draft |
 | [UC-002](UC-002_Create_New_Order.md) | Create New Order | `/newOrder` slash command | Bot Operator | Creates a Discord thread for a group purchase order and inserts a tracking record into the Notion Order List database (TBL-004); restricted to authorized operator only | Draft |
 | [UC-003](UC-003_Register_Buy_Record.md) | Register Buy Record | `/buy` slash command (reply) | Guild Member | Registers a purchase record into a member's personal transaction database (TBL-002) with JPY amount and auto-calculated TWD | Draft |
 
@@ -38,3 +39,4 @@
 | 1.0 | 2026/02/22 | — | Initial version — UC-001 registered |
 | 1.1 | 2026/03/18 | — | Add UC-002 (Create New Order), add Guild Member actor |
 | 1.2 | 2026/03/18 | — | Add UC-003 (Register Buy Record) |
+| 1.3 | 2026/04/05 | — | Add UC-004 (Trigger Debt Reminder), deprecate UC-001 |

--- a/docs/superpowers/plans/2026-04-05-debt-reminder-command.md
+++ b/docs/superpowers/plans/2026-04-05-debt-reminder-command.md
@@ -1,0 +1,632 @@
+# Debt Reminder Slash Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the cron-based unpaid notification (UC-001) with an on-demand `/debt-reminder` Discord slash command (UC-004) that runs immediately and schedules a one-shot delayed production run.
+
+**Architecture:** The existing `NotifyUnpaid` use case is simplified (remove day guard, clock dependency) and its `Execute` method gains a `debug` parameter. A new port interface `DebtReminder` wraps the use case for the command handler. A new slash command handler schedules the delayed run via gocron. The cron job and `WORKER_CORNTAB` config are removed.
+
+**Tech Stack:** Go, discordgo, gocron/v2, notionapi, testify
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `port/notifier.go` | Add `debug` param to `Notifier.Notify` |
+| Modify | `gateway/discord/notifier.go` | Accept `debug` per-call instead of struct field |
+| Modify | `gateway/discord/mock_test.go` | Update `newTestNotifier` (no debug field) |
+| Modify | `gateway/discord/notifier_test.go` | Pass `debug` to `Notify` calls |
+| Modify | `mocks/Notifier.go` | Regenerate (or hand-update) for new signature |
+| Modify | `usecase/notify_unpaid.go` | Remove day guard, clock; add `debug` param to `Execute` |
+| Modify | `usecase/notify_unpaid_test.go` | Remove day-guard tests, clock setup; pass `debug` param |
+| Create | `port/debt_reminder.go` | `DebtReminder` interface with `Execute(ctx, debug)` |
+| Create | `gateway/discord/command/debt_reminder_handler.go` | `/debt-reminder` slash command handler |
+| Modify | `config/config.go` | Remove `WorkerCrontab` field and validation |
+| Modify | `config/config_test.go` | Remove `WORKER_CORNTAB` test cases |
+| Modify | `main.go` | Remove cron job, wire new command, pass scheduler to handler |
+
+---
+
+### Task 1: Update `port/notifier.go` — add `debug` parameter
+
+**Files:**
+- Modify: `port/notifier.go`
+
+- [ ] **Step 1: Update the Notifier interface**
+
+Change `Notify` to accept a `debug bool` parameter:
+
+```go
+package port
+
+import (
+	"context"
+
+	"github.com/xgnid-tw/gx5/domain"
+)
+
+type Notifier interface {
+	Notify(ctx context.Context, user domain.User, debug bool) error
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add port/notifier.go
+git commit -m "refactor: add debug parameter to Notifier.Notify interface"
+```
+
+---
+
+### Task 2: Update `gateway/discord/notifier.go` — per-call debug
+
+**Files:**
+- Modify: `gateway/discord/notifier.go`
+- Modify: `gateway/discord/mock_test.go`
+- Modify: `gateway/discord/notifier_test.go`
+
+- [ ] **Step 1: Update Notifier struct and methods**
+
+Remove the `debug` field from the struct. Remove it from `NewNotifier`. Accept `debug` as a parameter in `Notify` and `sendDM`:
+
+```go
+type Notifier struct {
+	s            discordSession
+	logChannelID string
+}
+
+func NewNotifier(s *discordgo.Session, logChannelID string) *Notifier {
+	return &Notifier{s: s, logChannelID: logChannelID}
+}
+
+func (n *Notifier) Notify(_ context.Context, user domain.User, debug bool) error {
+	message := fmt.Sprintf(
+		"[欠費提醒] https://www.notion.so/%s (如果有漏登聯絡一下XG) ",
+		user.NotionID,
+	)
+
+	return n.sendDM(user.DiscordID, message, debug)
+}
+
+func (n *Notifier) sendDM(discordID string, message string, debug bool) error {
+	channel, err := n.s.UserChannelCreate(discordID)
+	if err != nil {
+		return fmt.Errorf("error creating channel: %w", err)
+	}
+
+	_, err = n.s.ChannelMessageSend(n.logChannelID, message)
+	if err != nil {
+		return fmt.Errorf("error sending to log channel: %w", err)
+	}
+
+	if debug {
+		log.Print("debug mode on")
+		return nil
+	}
+
+	_, err = n.s.ChannelMessageSend(channel.ID, message)
+	if err != nil {
+		return fmt.Errorf("error sending dm: %w", err)
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 2: Update mock_test.go — remove debug from newTestNotifier**
+
+```go
+func newTestNotifier(s discordSession, logChannelID string) *Notifier {
+	return &Notifier{s: s, logChannelID: logChannelID}
+}
+```
+
+- [ ] **Step 3: Update notifier_test.go — pass debug to Notify**
+
+Replace all `n.Notify(context.Background(), testUser)` calls:
+- `TestNotify_DebugMode_SkipsDM`: use `newTestNotifier(m, "log-chan")`, call `n.Notify(context.Background(), testUser, true)`
+- `TestNotify_NormalMode_SendsDM`: use `newTestNotifier(m, "log-chan")`, call `n.Notify(context.Background(), testUser, false)`
+- `TestNotify_UserChannelCreateFails`: use `newTestNotifier(m, "log-chan")`, call `n.Notify(context.Background(), testUser, false)`
+- `TestNotify_LogChannelSendFails`: use `newTestNotifier(m, "log-chan")`, call `n.Notify(context.Background(), testUser, false)`
+- `TestNotify_DMSendFails`: use `newTestNotifier(m, "log-chan")`, call `n.Notify(context.Background(), testUser, false)`
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./gateway/discord/...`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gateway/discord/notifier.go gateway/discord/mock_test.go gateway/discord/notifier_test.go
+git commit -m "refactor: make Notifier.debug a per-call parameter"
+```
+
+---
+
+### Task 3: Update `usecase/notify_unpaid.go` — remove day guard and clock, add debug param
+
+**Files:**
+- Modify: `usecase/notify_unpaid.go`
+- Modify: `usecase/notify_unpaid_test.go`
+
+- [ ] **Step 1: Simplify NotifyUnpaid**
+
+Remove `location`, `Clock` fields. Remove day guard. Add `debug` param to `Execute`, pass it to `notifier.Notify`:
+
+```go
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/xgnid-tw/gx5/domain"
+	"github.com/xgnid-tw/gx5/port"
+)
+
+const (
+	twdNotificationThreshold = 2000
+	jpyNotificationThreshold = 8000
+)
+
+var notificationAmountLimit = map[domain.Currency]float64{
+	domain.CurrencyTWD: twdNotificationThreshold,
+	domain.CurrencyJPY: jpyNotificationThreshold,
+}
+
+type NotifyUnpaid struct {
+	repo       port.UserRepository
+	notifier   port.Notifier
+	othersDBID string
+}
+
+func NewNotifyUnpaid(
+	repo port.UserRepository, notifier port.Notifier,
+	othersDBID string,
+) *NotifyUnpaid {
+	return &NotifyUnpaid{
+		repo: repo, notifier: notifier,
+		othersDBID: othersDBID,
+	}
+}
+
+func (uc *NotifyUnpaid) Execute(ctx context.Context, debug bool) error {
+	users, err := uc.repo.GetUsers(ctx)
+	if err != nil {
+		return fmt.Errorf("get users: %w", err)
+	}
+
+	for _, u := range users {
+		shouldNotify, err := uc.shouldNotifyUser(ctx, u)
+		if err != nil {
+			return err
+		}
+
+		if shouldNotify {
+			err = uc.notifier.Notify(ctx, *u, debug)
+			if err != nil {
+				log.Printf("notify %s: %s", u.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+```
+
+(`shouldNotifyUser` stays unchanged.)
+
+- [ ] **Step 2: Update tests**
+
+Remove `TestExecute_NotFirstOfMonth_SkipsAll` (day guard no longer exists).
+
+Remove `mockClock` helper, `testLocation` var, and all `clock` imports.
+
+Update `NewNotifyUnpaid` calls — remove the `testLocation` parameter:
+```go
+uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
+```
+
+Remove all `uc.Clock = mockClock(...)` lines.
+
+Update `uc.Execute(context.Background())` → `uc.Execute(context.Background(), false)` in all tests.
+
+Update `notifier.On("Notify", ...)` — add `false` as the third argument after `*user`:
+```go
+notifier.On("Notify", mock.Anything, *user, false).Return(nil)
+```
+
+- [ ] **Step 3: Regenerate mocks**
+
+Run: `go generate ./mocks/... || mockery`
+
+If mockery is not available, hand-update `mocks/Notifier.go`:
+- Change `Notify` signature to `Notify(ctx context.Context, user domain.User, debug bool) error`
+- Update `_m.Called(ctx, user, debug)`
+- Update the type assertion to `func(context.Context, domain.User, bool) error`
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./usecase/... ./gateway/discord/...`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add usecase/notify_unpaid.go usecase/notify_unpaid_test.go mocks/Notifier.go
+git commit -m "refactor: remove day guard and clock from NotifyUnpaid, add debug param"
+```
+
+---
+
+### Task 4: Create `port/debt_reminder.go` — DebtReminder interface
+
+**Files:**
+- Create: `port/debt_reminder.go`
+
+- [ ] **Step 1: Create the interface**
+
+```go
+package port
+
+import "context"
+
+type DebtReminder interface {
+	Execute(ctx context.Context, debug bool) error
+}
+```
+
+- [ ] **Step 2: Verify NotifyUnpaid satisfies the interface**
+
+Run: `go build ./...`
+Expected: compiles without error (NotifyUnpaid already has `Execute(ctx, debug)`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add port/debt_reminder.go
+git commit -m "feat: add DebtReminder port interface"
+```
+
+---
+
+### Task 5: Create `/debt-reminder` slash command handler
+
+**Files:**
+- Create: `gateway/discord/command/debt_reminder_handler.go`
+
+- [ ] **Step 1: Create the handler**
+
+```go
+package command
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/go-co-op/gocron/v2"
+
+	"github.com/xgnid-tw/gx5/port"
+)
+
+const (
+	debtReminderCommandName = "debt-reminder"
+	defaultDays             = 15
+)
+
+// RegisterDebtReminderCommand registers the /debt-reminder slash command and its handler.
+func RegisterDebtReminderCommand(ch *Handler, uc port.DebtReminder, scheduler gocron.Scheduler) {
+	adminPerm := int64(discordgo.PermissionAdministrator)
+
+	cmd := &discordgo.ApplicationCommand{
+		Name:                     debtReminderCommandName,
+		Description:              "立即執行欠費提醒，並排程於指定天數後再次執行",
+		DefaultMemberPermissions: &adminPerm,
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionInteger,
+				Name:        "days",
+				Description: "幾天後再次執行（預設 15 天）",
+				Required:    false,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Name:        "debug",
+				Description: "除錯模式（僅傳送至 log 頻道，不發送 DM）",
+				Required:    false,
+			},
+		},
+	}
+
+	ch.RegisterCommand(cmd, func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		handleDebtReminder(s, i, uc, scheduler)
+	})
+}
+
+func handleDebtReminder(
+	s *discordgo.Session, i *discordgo.InteractionCreate,
+	uc port.DebtReminder, scheduler gocron.Scheduler,
+) {
+	respondDeferred(s, i)
+
+	opts := i.ApplicationCommandData().Options
+	optMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(opts))
+	for _, opt := range opts {
+		optMap[opt.Name] = opt
+	}
+
+	days := int64(defaultDays)
+	if v, ok := optMap["days"]; ok {
+		days = v.IntValue()
+	}
+
+	debug := false
+	if v, ok := optMap["debug"]; ok {
+		debug = v.BoolValue()
+	}
+
+	// Immediate run
+	err := uc.Execute(context.Background(), debug)
+	if err != nil {
+		log.Printf("debt-reminder immediate run failed: %s", err)
+	}
+
+	// Schedule delayed production run
+	runAt := time.Now().Add(time.Duration(days) * 24 * time.Hour)
+
+	_, err = scheduler.NewJob(
+		gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(runAt)),
+		gocron.NewTask(func() {
+			log.Print("debt-reminder scheduled run")
+			if err := uc.Execute(context.Background(), false); err != nil {
+				log.Printf("debt-reminder scheduled run failed: %s", err)
+			}
+		}),
+	)
+	if err != nil {
+		log.Printf("debt-reminder schedule failed: %s", err)
+		editDeferredResponse(s, i, fmt.Sprintf(
+			"提醒已執行（模式: %s），但排程失敗: %s",
+			modeLabel(debug), err,
+		))
+
+		return
+	}
+
+	editDeferredResponse(s, i, fmt.Sprintf(
+		"提醒已執行（模式: %s）。下次執行: %s（正式模式）",
+		modeLabel(debug),
+		runAt.Format("2006-01-02 15:04"),
+	))
+}
+
+func modeLabel(debug bool) string {
+	if debug {
+		return "除錯"
+	}
+
+	return "正式"
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `go build ./...`
+Expected: compiles without error
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gateway/discord/command/debt_reminder_handler.go
+git commit -m "feat: add /debt-reminder slash command handler"
+```
+
+---
+
+### Task 6: Remove `WORKER_CORNTAB` from config
+
+**Files:**
+- Modify: `config/config.go`
+- Modify: `config/config_test.go`
+
+- [ ] **Step 1: Remove WorkerCrontab from Config struct and Load**
+
+In `config/config.go`:
+- Remove `WorkerCrontab string` from the `Config` struct
+- Remove `WorkerCrontab: os.Getenv("WORKER_CORNTAB"),` from `Load()`
+- Remove the validation block:
+  ```go
+  if cfg.WorkerCrontab == "" {
+      return Config{}, fmt.Errorf("WORKER_CORNTAB is required")
+  }
+  ```
+
+- [ ] **Step 2: Update config_test.go**
+
+Remove any test cases that reference `WORKER_CORNTAB`. Check the file first — if tests set this env var, remove those lines.
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./config/...`
+Expected: all PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/config.go config/config_test.go
+git commit -m "refactor: remove WORKER_CORNTAB from config"
+```
+
+---
+
+### Task 7: Update `main.go` — remove cron job, wire new command
+
+**Files:**
+- Modify: `main.go`
+
+- [ ] **Step 1: Rewrite main.go**
+
+Key changes:
+- Remove `clock` import
+- Remove `WORKER_CORNTAB` / crontab / debug-clock block (lines 74-81)
+- Remove the cron job registration (lines 89-99)
+- Keep scheduler creation (needed for one-shot jobs)
+- Update `NewNotifier` call — remove `cfg.Debug` parameter
+- Update `NewNotifyUnpaid` call — remove `loc` parameter
+- Register the new `/debt-reminder` command, passing the scheduler
+- Keep scheduler `Start()` and `Shutdown()` (scheduler still manages delayed jobs)
+
+Updated main.go:
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/go-co-op/gocron/v2"
+	"github.com/joho/godotenv"
+	"github.com/jomei/notionapi"
+
+	"github.com/xgnid-tw/gx5/config"
+	discordgw "github.com/xgnid-tw/gx5/gateway/discord"
+	discordcmd "github.com/xgnid-tw/gx5/gateway/discord/command"
+	notiongw "github.com/xgnid-tw/gx5/gateway/notion"
+	"github.com/xgnid-tw/gx5/usecase"
+)
+
+func main() {
+	err := godotenv.Load(".env")
+	if err != nil {
+		log.Fatal("can not fetch env")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("invalid config: %s", err)
+	}
+
+	// Initialize external service clients
+	dc, err := discordgo.New(cfg.DiscordToken)
+	if err != nil {
+		log.Fatalf("can not create discord session: %s", err)
+	}
+
+	dc.Identify.Intents = discordgo.IntentsAll
+
+	notionClient := notionapi.NewClient(notionapi.Token(cfg.NotionToken))
+
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		log.Fatalf("invalid location: %s", err)
+	}
+
+	// Wire dependencies: gateway adapters -> use cases
+	repo := notiongw.NewRepository(notionClient.Database, cfg.NotionUserDBID, cfg.NotionOthersDBID)
+	notifier := discordgw.NewNotifier(dc, cfg.DiscordLogChannelID)
+	notifyUnpaidUC := usecase.NewNotifyUnpaid(repo, notifier, cfg.NotionOthersDBID)
+
+	orderRepo := notiongw.NewOrderRepository(notionClient.Page, cfg.NotionOrderDBID)
+	threadCreator := discordgw.NewThreadCreator(dc)
+	memberAdder := discordgw.NewMemberAdder(dc, cfg.DiscordGuildID)
+	createOrderUC := usecase.NewCreateOrder(orderRepo, threadCreator, memberAdder, cfg.TagRoleMap)
+
+	txRepo := notiongw.NewTransactionRepository(notionClient.Page)
+	buyUC := usecase.NewRegisterBuyRecord(repo, txRepo, cfg.ExchangeRateJPYTWD)
+
+	// Scheduler for one-shot delayed jobs
+	s, err := gocron.NewScheduler(gocron.WithLocation(loc))
+	if err != nil {
+		log.Fatalf("can not create scheduler: %s", err)
+	}
+
+	// Register Discord application commands
+	cmdHandler := discordcmd.NewHandler(dc, cfg.DiscordAppID)
+
+	discordcmd.RegisterNewOrderCommand(cmdHandler, createOrderUC)
+	discordcmd.RegisterBuyCommand(cmdHandler, buyUC)
+	discordcmd.RegisterDebtReminderCommand(cmdHandler, notifyUnpaidUC, s)
+
+	// Open Discord connection and start the scheduler
+	err = dc.Open()
+	if err != nil {
+		log.Fatalf("error opening connection: %s", err)
+	}
+
+	err = cmdHandler.SyncCommands()
+	if err != nil {
+		_ = dc.Close()
+
+		log.Fatalf("error syncing commands: %s", err)
+	}
+
+	defer cmdHandler.UnregisterAll()
+	defer dc.Close()
+
+	log.Print("Bot is now running. Press CTRL-C to exit.")
+
+	s.Start()
+
+	// Block until termination signal
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+	<-sc
+
+	_ = s.Shutdown()
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `go build ./...`
+Expected: compiles without error
+
+- [ ] **Step 3: Run all tests**
+
+Run: `go test ./...`
+Expected: all PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main.go
+git commit -m "feat: wire /debt-reminder command, remove cron-based scheduler"
+```
+
+---
+
+### Task 8: Clean up — remove unused dependencies
+
+**Files:**
+- Modify: `go.mod` / `go.sum`
+
+- [ ] **Step 1: Tidy modules**
+
+Run: `go mod tidy`
+
+This should remove `github.com/benbjohnson/clock` if no longer imported anywhere.
+
+- [ ] **Step 2: Verify**
+
+Run: `go build ./... && go test ./...`
+Expected: all PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "chore: go mod tidy, remove unused clock dependency"
+```

--- a/gateway/discord/command/debt_reminder_handler.go
+++ b/gateway/discord/command/debt_reminder_handler.go
@@ -53,6 +53,7 @@ func handleDebtReminder(
 	respondDeferred(s, i)
 
 	opts := i.ApplicationCommandData().Options
+
 	optMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(opts))
 	for _, opt := range opts {
 		optMap[opt.Name] = opt
@@ -81,7 +82,9 @@ func handleDebtReminder(
 		gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(runAt)),
 		gocron.NewTask(func() {
 			log.Print("debt-reminder scheduled run")
-			if err := uc.Execute(context.Background(), false); err != nil {
+
+			err := uc.Execute(context.Background(), false)
+			if err != nil {
 				log.Printf("debt-reminder scheduled run failed: %s", err)
 			}
 		}),

--- a/gateway/discord/command/debt_reminder_handler.go
+++ b/gateway/discord/command/debt_reminder_handler.go
@@ -1,0 +1,112 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/go-co-op/gocron/v2"
+
+	"github.com/xgnid-tw/gx5/port"
+)
+
+const (
+	debtReminderCommandName = "debt-reminder"
+	defaultDays             = 15
+)
+
+// RegisterDebtReminderCommand registers the /debt-reminder slash command and its handler.
+func RegisterDebtReminderCommand(ch *Handler, uc port.DebtReminder, scheduler gocron.Scheduler) {
+	adminPerm := int64(discordgo.PermissionAdministrator)
+
+	cmd := &discordgo.ApplicationCommand{
+		Name:                     debtReminderCommandName,
+		Description:              "立即執行欠費提醒，並排程於指定天數後再次執行",
+		DefaultMemberPermissions: &adminPerm,
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionInteger,
+				Name:        "days",
+				Description: "幾天後再次執行（預設 15 天）",
+				Required:    false,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Name:        "debug",
+				Description: "除錯模式（僅傳送至 log 頻道，不發送 DM）",
+				Required:    false,
+			},
+		},
+	}
+
+	ch.RegisterCommand(cmd, func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		handleDebtReminder(s, i, uc, scheduler)
+	})
+}
+
+func handleDebtReminder(
+	s *discordgo.Session, i *discordgo.InteractionCreate,
+	uc port.DebtReminder, scheduler gocron.Scheduler,
+) {
+	respondDeferred(s, i)
+
+	opts := i.ApplicationCommandData().Options
+	optMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(opts))
+	for _, opt := range opts {
+		optMap[opt.Name] = opt
+	}
+
+	days := int64(defaultDays)
+	if v, ok := optMap["days"]; ok {
+		days = v.IntValue()
+	}
+
+	debug := false
+	if v, ok := optMap["debug"]; ok {
+		debug = v.BoolValue()
+	}
+
+	// Immediate run
+	err := uc.Execute(context.Background(), debug)
+	if err != nil {
+		log.Printf("debt-reminder immediate run failed: %s", err)
+	}
+
+	// Schedule delayed production run
+	runAt := time.Now().Add(time.Duration(days) * 24 * time.Hour)
+
+	_, err = scheduler.NewJob(
+		gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(runAt)),
+		gocron.NewTask(func() {
+			log.Print("debt-reminder scheduled run")
+			if err := uc.Execute(context.Background(), false); err != nil {
+				log.Printf("debt-reminder scheduled run failed: %s", err)
+			}
+		}),
+	)
+	if err != nil {
+		log.Printf("debt-reminder schedule failed: %s", err)
+		editDeferredResponse(s, i, fmt.Sprintf(
+			"提醒已執行（模式: %s），但排程失敗: %s",
+			modeLabel(debug), err,
+		))
+
+		return
+	}
+
+	editDeferredResponse(s, i, fmt.Sprintf(
+		"提醒已執行（模式: %s）。下次執行: %s（正式模式）",
+		modeLabel(debug),
+		runAt.Format("2006-01-02 15:04"),
+	))
+}
+
+func modeLabel(debug bool) string {
+	if debug {
+		return "除錯"
+	}
+
+	return "正式"
+}

--- a/gateway/discord/command/debt_reminder_handler.go
+++ b/gateway/discord/command/debt_reminder_handler.go
@@ -14,7 +14,10 @@ import (
 
 const (
 	debtReminderCommandName = "debt-reminder"
+	debtReminderOptionDays  = "days"
+	debtReminderOptionDebug = "debug"
 	defaultDays             = 15
+	minDays                 = 1
 )
 
 // RegisterDebtReminderCommand registers the /debt-reminder slash command and its handler.
@@ -28,13 +31,13 @@ func RegisterDebtReminderCommand(ch *Handler, uc port.DebtReminder, scheduler go
 		Options: []*discordgo.ApplicationCommandOption{
 			{
 				Type:        discordgo.ApplicationCommandOptionInteger,
-				Name:        "days",
+				Name:        debtReminderOptionDays,
 				Description: "幾天後再次執行（預設 15 天）",
 				Required:    false,
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionBoolean,
-				Name:        "debug",
+				Name:        debtReminderOptionDebug,
 				Description: "除錯模式（僅傳送至 log 頻道，不發送 DM）",
 				Required:    false,
 			},
@@ -60,12 +63,17 @@ func handleDebtReminder(
 	}
 
 	days := int64(defaultDays)
-	if v, ok := optMap["days"]; ok {
+	if v, ok := optMap[debtReminderOptionDays]; ok {
 		days = v.IntValue()
 	}
 
+	if days < minDays {
+		editDeferredResponse(s, i, fmt.Sprintf("天數必須至少為 %d", minDays))
+		return
+	}
+
 	debug := false
-	if v, ok := optMap["debug"]; ok {
+	if v, ok := optMap[debtReminderOptionDebug]; ok {
 		debug = v.BoolValue()
 	}
 
@@ -73,6 +81,9 @@ func handleDebtReminder(
 	err := uc.Execute(context.Background(), debug)
 	if err != nil {
 		log.Printf("debt-reminder immediate run failed: %s", err)
+		editDeferredResponse(s, i, fmt.Sprintf("提醒執行失敗: %s", err))
+
+		return
 	}
 
 	// Schedule delayed production run

--- a/gateway/discord/mock_test.go
+++ b/gateway/discord/mock_test.go
@@ -29,6 +29,6 @@ func (m *mockDiscordSession) ChannelMessageSend(
 	return m.channelMessageSendFn(channelID, content, options...)
 }
 
-func newTestNotifier(s discordSession, logChannelID string, debug bool) *Notifier {
-	return &Notifier{s: s, logChannelID: logChannelID, debug: debug}
+func newTestNotifier(s discordSession, logChannelID string) *Notifier {
+	return &Notifier{s: s, logChannelID: logChannelID}
 }

--- a/gateway/discord/notifier.go
+++ b/gateway/discord/notifier.go
@@ -19,23 +19,22 @@ type discordSession interface {
 type Notifier struct {
 	s            discordSession
 	logChannelID string
-	debug        bool
 }
 
-func NewNotifier(s *discordgo.Session, logChannelID string, debug bool) *Notifier {
-	return &Notifier{s: s, logChannelID: logChannelID, debug: debug}
+func NewNotifier(s *discordgo.Session, logChannelID string) *Notifier {
+	return &Notifier{s: s, logChannelID: logChannelID}
 }
 
-func (n *Notifier) Notify(_ context.Context, user domain.User) error {
+func (n *Notifier) Notify(_ context.Context, user domain.User, debug bool) error {
 	message := fmt.Sprintf(
 		"[欠費提醒] https://www.notion.so/%s (如果有漏登聯絡一下XG) ",
 		user.NotionID,
 	)
 
-	return n.sendDM(user.DiscordID, message)
+	return n.sendDM(user.DiscordID, message, debug)
 }
 
-func (n *Notifier) sendDM(discordID string, message string) error {
+func (n *Notifier) sendDM(discordID string, message string, debug bool) error {
 	channel, err := n.s.UserChannelCreate(discordID)
 	if err != nil {
 		return fmt.Errorf("error creating channel: %w", err)
@@ -46,7 +45,7 @@ func (n *Notifier) sendDM(discordID string, message string) error {
 		return fmt.Errorf("error sending to log channel: %w", err)
 	}
 
-	if n.debug {
+	if debug {
 		log.Print("debug mode on")
 		return nil
 	}

--- a/gateway/discord/notifier_test.go
+++ b/gateway/discord/notifier_test.go
@@ -23,8 +23,8 @@ func TestNotify_DebugMode_SkipsDM(t *testing.T) {
 		},
 	}
 
-	n := newTestNotifier(m, "log-chan", true)
-	err := n.Notify(context.Background(), testUser)
+	n := newTestNotifier(m, "log-chan")
+	err := n.Notify(context.Background(), testUser, true)
 
 	require.NoError(t, err)
 	require.Len(t, m.sentMessages, 1)
@@ -41,8 +41,8 @@ func TestNotify_NormalMode_SendsDM(t *testing.T) {
 		},
 	}
 
-	n := newTestNotifier(m, "log-chan", false)
-	err := n.Notify(context.Background(), testUser)
+	n := newTestNotifier(m, "log-chan")
+	err := n.Notify(context.Background(), testUser, false)
 
 	require.NoError(t, err)
 	require.Len(t, m.sentMessages, 2)
@@ -61,8 +61,8 @@ func TestNotify_UserChannelCreateFails(t *testing.T) {
 		},
 	}
 
-	n := newTestNotifier(m, "log-chan", false)
-	err := n.Notify(context.Background(), testUser)
+	n := newTestNotifier(m, "log-chan")
+	err := n.Notify(context.Background(), testUser, false)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "error creating channel")
@@ -78,8 +78,8 @@ func TestNotify_LogChannelSendFails(t *testing.T) {
 		},
 	}
 
-	n := newTestNotifier(m, "log-chan", false)
-	err := n.Notify(context.Background(), testUser)
+	n := newTestNotifier(m, "log-chan")
+	err := n.Notify(context.Background(), testUser, false)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "error sending to log channel")
@@ -101,8 +101,8 @@ func TestNotify_DMSendFails(t *testing.T) {
 		},
 	}
 
-	n := newTestNotifier(m, "log-chan", false)
-	err := n.Notify(context.Background(), testUser)
+	n := newTestNotifier(m, "log-chan")
+	err := n.Notify(context.Background(), testUser, false)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "error sending dm")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 )
 
 require (
-	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/chigopher/pathlib v0.19.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
-github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/chigopher/pathlib v0.19.1 h1:RoLlUJc0CqBGwq239cilyhxPNLXTK+HXoASGyGznx5A=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"log"
 	"os"
 	"os/signal"
@@ -31,8 +30,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("invalid config: %s", err)
 	}
-
-	ctx := context.Background()
 
 	// Initialize external service clients
 	dc, err := discordgo.New(cfg.DiscordToken)
@@ -66,33 +63,15 @@ func main() {
 	// Register Discord application commands
 	cmdHandler := discordcmd.NewHandler(dc, cfg.DiscordAppID)
 
-	discordcmd.RegisterNewOrderCommand(cmdHandler, createOrderUC)
-	discordcmd.RegisterBuyCommand(cmdHandler, buyUC)
-
-	// In debug mode, run the job every minute
-	crontab := cfg.WorkerCrontab
-
-	if cfg.Debug {
-		crontab = "*/1 * * * *"
-	}
-
+	// Scheduler for one-shot delayed jobs
 	s, err := gocron.NewScheduler(gocron.WithLocation(loc))
 	if err != nil {
 		log.Fatalf("can not create scheduler: %s", err)
 	}
 
-	// Register the unpaid notification job on the configured cron schedule
-	_, err = s.NewJob(gocron.CronJob(crontab, false), gocron.NewTask(func() {
-		log.Print("run job")
-
-		err := notifyUnpaidUC.Execute(ctx, cfg.Debug)
-		if err != nil {
-			log.Printf("worker: %s", err)
-		}
-	}))
-	if err != nil {
-		log.Fatalf("can not start scheduler: %s", err)
-	}
+	discordcmd.RegisterNewOrderCommand(cmdHandler, createOrderUC)
+	discordcmd.RegisterBuyCommand(cmdHandler, buyUC)
+	discordcmd.RegisterDebtReminderCommand(cmdHandler, notifyUnpaidUC, s)
 
 	// Open Discord connection and start the scheduler
 	err = dc.Open()

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/bwmarrin/discordgo"
 	"github.com/go-co-op/gocron/v2"
 	"github.com/joho/godotenv"
@@ -45,7 +44,7 @@ func main() {
 
 	notionClient := notionapi.NewClient(notionapi.Token(cfg.NotionToken))
 
-	// Load Asia/Tokyo timezone for scheduler and use case day guard
+	// Load Asia/Tokyo timezone for scheduler
 	loc, err := time.LoadLocation("Asia/Tokyo")
 	if err != nil {
 		log.Fatalf("invalid location: %s", err)
@@ -53,8 +52,8 @@ func main() {
 
 	// Wire dependencies: gateway adapters -> use cases
 	repo := notiongw.NewRepository(notionClient.Database, cfg.NotionUserDBID, cfg.NotionOthersDBID)
-	notifier := discordgw.NewNotifier(dc, cfg.DiscordLogChannelID, cfg.Debug)
-	notifyUnpaidUC := usecase.NewNotifyUnpaid(repo, notifier, cfg.NotionOthersDBID, loc)
+	notifier := discordgw.NewNotifier(dc, cfg.DiscordLogChannelID)
+	notifyUnpaidUC := usecase.NewNotifyUnpaid(repo, notifier, cfg.NotionOthersDBID)
 
 	orderRepo := notiongw.NewOrderRepository(notionClient.Page, cfg.NotionOrderDBID)
 	threadCreator := discordgw.NewThreadCreator(dc)
@@ -70,13 +69,10 @@ func main() {
 	discordcmd.RegisterNewOrderCommand(cmdHandler, createOrderUC)
 	discordcmd.RegisterBuyCommand(cmdHandler, buyUC)
 
-	// In debug mode, fake the clock and run the job every minute
+	// In debug mode, run the job every minute
 	crontab := cfg.WorkerCrontab
 
 	if cfg.Debug {
-		clk := clock.NewMock()
-		clk.Set(time.Date(time.Now().Year(), time.Now().Month(), 1, 9, 0, 0, 0, loc))
-		notifyUnpaidUC.Clock = clk
 		crontab = "*/1 * * * *"
 	}
 
@@ -89,7 +85,7 @@ func main() {
 	_, err = s.NewJob(gocron.CronJob(crontab, false), gocron.NewTask(func() {
 		log.Print("run job")
 
-		err := notifyUnpaidUC.Execute(ctx)
+		err := notifyUnpaidUC.Execute(ctx, cfg.Debug)
 		if err != nil {
 			log.Printf("worker: %s", err)
 		}

--- a/mocks/Notifier.go
+++ b/mocks/Notifier.go
@@ -14,17 +14,17 @@ type Notifier struct {
 	mock.Mock
 }
 
-// Notify provides a mock function with given fields: ctx, user
-func (_m *Notifier) Notify(ctx context.Context, user domain.User) error {
-	ret := _m.Called(ctx, user)
+// Notify provides a mock function with given fields: ctx, user, debug
+func (_m *Notifier) Notify(ctx context.Context, user domain.User, debug bool) error {
+	ret := _m.Called(ctx, user, debug)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Notify")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, domain.User) error); ok {
-		r0 = rf(ctx, user)
+	if rf, ok := ret.Get(0).(func(context.Context, domain.User, bool) error); ok {
+		r0 = rf(ctx, user, debug)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/port/debt_reminder.go
+++ b/port/debt_reminder.go
@@ -1,0 +1,7 @@
+package port
+
+import "context"
+
+type DebtReminder interface {
+	Execute(ctx context.Context, debug bool) error
+}

--- a/port/notifier.go
+++ b/port/notifier.go
@@ -7,5 +7,5 @@ import (
 )
 
 type Notifier interface {
-	Notify(ctx context.Context, user domain.User) error
+	Notify(ctx context.Context, user domain.User, debug bool) error
 }

--- a/usecase/notify_unpaid.go
+++ b/usecase/notify_unpaid.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
-
-	"github.com/benbjohnson/clock"
 
 	"github.com/xgnid-tw/gx5/domain"
 	"github.com/xgnid-tw/gx5/port"
@@ -26,27 +23,19 @@ type NotifyUnpaid struct {
 	repo       port.UserRepository
 	notifier   port.Notifier
 	othersDBID string
-	location   *time.Location
-	Clock      clock.Clock
 }
 
 func NewNotifyUnpaid(
 	repo port.UserRepository, notifier port.Notifier,
-	othersDBID string, loc *time.Location,
+	othersDBID string,
 ) *NotifyUnpaid {
 	return &NotifyUnpaid{
 		repo: repo, notifier: notifier,
-		othersDBID: othersDBID, location: loc,
-		Clock: clock.New(),
+		othersDBID: othersDBID,
 	}
 }
 
-func (uc *NotifyUnpaid) Execute(ctx context.Context) error {
-	day := uc.Clock.Now().In(uc.location).Day()
-	if day != 1 && day != 15 {
-		return nil
-	}
-
+func (uc *NotifyUnpaid) Execute(ctx context.Context, debug bool) error {
 	users, err := uc.repo.GetUsers(ctx)
 	if err != nil {
 		return fmt.Errorf("get users: %w", err)
@@ -59,7 +48,7 @@ func (uc *NotifyUnpaid) Execute(ctx context.Context) error {
 		}
 
 		if shouldNotify {
-			err = uc.notifier.Notify(ctx, *u)
+			err = uc.notifier.Notify(ctx, *u, debug)
 			if err != nil {
 				log.Printf("notify %s: %s", u.Name, err)
 			}

--- a/usecase/notify_unpaid_test.go
+++ b/usecase/notify_unpaid_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -17,37 +15,15 @@ import (
 
 const testOthersDBID = "others-db"
 
-var testLocation = time.UTC
-
-func mockClock(t time.Time) *clock.Mock {
-	clk := clock.NewMock()
-	clk.Set(t)
-
-	return clk
-}
-
-func TestExecute_NotFirstOfMonth_SkipsAll(t *testing.T) {
-	repo := mocks.NewUserRepository(t)
-	notifier := mocks.NewNotifier(t)
-
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 10, 9, 0, 0, 0, time.UTC))
-
-	err := uc.Execute(context.Background())
-
-	require.NoError(t, err)
-}
-
 func TestExecute_GetUsersError(t *testing.T) {
 	repo := mocks.NewUserRepository(t)
 	notifier := mocks.NewNotifier(t)
 
 	repo.On("GetUsers", mock.Anything).Return(nil, errors.New("db error"))
 
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-	err := uc.Execute(context.Background())
+	err := uc.Execute(context.Background(), false)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "get users")
@@ -66,10 +42,9 @@ func TestExecute_GetUnpaidAmountError(t *testing.T) {
 	repo.On("GetUnpaidAmount", mock.Anything, "abc", domain.CurrencyTWD).
 		Return(float64(0), errors.New("notion error"))
 
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-	err := uc.Execute(context.Background())
+	err := uc.Execute(context.Background(), false)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "get unpaid amount")
@@ -88,47 +63,33 @@ func TestExecute_GetOthersUnpaidAmountError(t *testing.T) {
 	repo.On("GetOthersUnpaidAmount", mock.Anything, "Alice", domain.CurrencyTWD).
 		Return(float64(0), errors.New("notion error"))
 
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-	err := uc.Execute(context.Background())
+	err := uc.Execute(context.Background(), false)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "get others unpaid amount")
 }
 
 func TestExecute_PersonalDB_AboveThreshold_Notified(t *testing.T) {
-	tests := []struct {
-		name string
-		day  int
-	}{
-		{"on 1st", 1},
-		{"on 15th", 15},
+	repo := mocks.NewUserRepository(t)
+	notifier := mocks.NewNotifier(t)
+
+	user := &domain.User{
+		DiscordID: "111", Name: "Alice",
+		NotionID: "abc", Currency: domain.CurrencyTWD,
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			repo := mocks.NewUserRepository(t)
-			notifier := mocks.NewNotifier(t)
+	repo.On("GetUsers", mock.Anything).Return([]*domain.User{user}, nil)
+	repo.On("GetUnpaidAmount", mock.Anything, "abc", domain.CurrencyTWD).
+		Return(float64(3000), nil)
+	notifier.On("Notify", mock.Anything, *user, false).Return(nil)
 
-			user := &domain.User{
-				DiscordID: "111", Name: "Alice",
-				NotionID: "abc", Currency: domain.CurrencyTWD,
-			}
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-			repo.On("GetUsers", mock.Anything).Return([]*domain.User{user}, nil)
-			repo.On("GetUnpaidAmount", mock.Anything, "abc", domain.CurrencyTWD).
-				Return(float64(3000), nil)
-			notifier.On("Notify", mock.Anything, *user).Return(nil)
+	err := uc.Execute(context.Background(), false)
 
-			uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-			uc.Clock = mockClock(time.Date(2026, 1, tt.day, 9, 0, 0, 0, time.UTC))
-
-			err := uc.Execute(context.Background())
-
-			require.NoError(t, err)
-		})
-	}
+	require.NoError(t, err)
 }
 
 func TestExecute_OthersDB_AboveThreshold_Notified(t *testing.T) {
@@ -143,12 +104,11 @@ func TestExecute_OthersDB_AboveThreshold_Notified(t *testing.T) {
 	repo.On("GetUsers", mock.Anything).Return([]*domain.User{user}, nil)
 	repo.On("GetOthersUnpaidAmount", mock.Anything, "Carol", domain.CurrencyTWD).
 		Return(float64(2500), nil)
-	notifier.On("Notify", mock.Anything, *user).Return(nil)
+	notifier.On("Notify", mock.Anything, *user, false).Return(nil)
 
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-	err := uc.Execute(context.Background())
+	err := uc.Execute(context.Background(), false)
 
 	require.NoError(t, err)
 }
@@ -166,10 +126,9 @@ func TestExecute_PersonalDB_ZeroAmount_NotNotified(t *testing.T) {
 	repo.On("GetUnpaidAmount", mock.Anything, "abc", domain.CurrencyTWD).
 		Return(float64(0), nil)
 
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-	err := uc.Execute(context.Background())
+	err := uc.Execute(context.Background(), false)
 
 	require.NoError(t, err)
 }
@@ -187,10 +146,9 @@ func TestExecute_OthersDB_ZeroAmount_NotNotified(t *testing.T) {
 	repo.On("GetOthersUnpaidAmount", mock.Anything, "Carol", domain.CurrencyTWD).
 		Return(float64(0), nil)
 
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-	err := uc.Execute(context.Background())
+	err := uc.Execute(context.Background(), false)
 
 	require.NoError(t, err)
 }
@@ -213,14 +171,13 @@ func TestExecute_NotifyError_ContinuesNextUser(t *testing.T) {
 		Return(float64(3000), nil)
 	repo.On("GetUnpaidAmount", mock.Anything, "def", domain.CurrencyTWD).
 		Return(float64(3000), nil)
-	notifier.On("Notify", mock.Anything, *user1).
+	notifier.On("Notify", mock.Anything, *user1, false).
 		Return(errors.New("discord error"))
-	notifier.On("Notify", mock.Anything, *user2).Return(nil)
+	notifier.On("Notify", mock.Anything, *user2, false).Return(nil)
 
-	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID, testLocation)
-	uc.Clock = mockClock(time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC))
+	uc := usecase.NewNotifyUnpaid(repo, notifier, testOthersDBID)
 
-	err := uc.Execute(context.Background())
+	err := uc.Execute(context.Background(), false)
 
 	require.NoError(t, err)
 }


### PR DESCRIPTION
  - Replace cron-based unpaid notification (UC-001) with on-demand /debt-reminder slash command (UC-004)
  - /debt-reminder days=N debug=true/false runs reminder immediately and schedules a one-shot production run N days later                                                                                                                         
  - Remove WORKER_CORNTAB env var, day guard (1st/15th check), and clock dependency                                      
  - debug flag is now per-invocation instead of global env var                                                                                                                                                                                    
                                                                  